### PR TITLE
Changes to autoPublishes

### DIFF
--- a/src/Netflex/Query/QueryableModel.php
+++ b/src/Netflex/Query/QueryableModel.php
@@ -431,10 +431,6 @@ abstract class QueryableModel implements Arrayable, ArrayAccess, Jsonable, JsonS
         if (count($dirty) > 0) {
           $dirty['revision_publish'] = true;
 
-          if ($this->autoPublishes) {
-            $dirty['published'] = true;
-          }
-
           $this->performUpdateRequest($this->getRelationId(), $this->getKey(), $dirty);
         }
 

--- a/src/Netflex/Query/QueryableModel.php
+++ b/src/Netflex/Query/QueryableModel.php
@@ -480,7 +480,7 @@ abstract class QueryableModel implements Arrayable, ArrayAccess, Jsonable, JsonS
     $attributes['revision_publish'] = true;
     $attributes['name'] = $attributes['name'] ?? uuid();
 
-    if ($this->autoPublishes) {
+    if ($this->autoPublishes && !array_key_exists("published", $this->getDirty())) {
       $attributes['published'] = true;
     }
 


### PR DESCRIPTION
This PR makes two changes to Auto Publishing using the `$autoPublishes` settings on the queryable model. It fixes some side effects of the implementation rendering publishing status entirely useless by default in Netflex, when considering entries being created.

This caused me a lot of headache today when syncing some data between sites because without me turning it on, the model just disregarded my attempts at setting publishing status, without any feedback. Even `getDirty()` would advise me that my change was registered and valid. Yet when saving, the changes did not propagate. This was because `autoPublishes` is on by default. This caused published to be set to true by default, despite myself wanting to set published to false.

This is a horrible change in itself in my opinion. As this breaks expected behavior between both the old Netflex and entries created through the Netflexapp UI. Both where a new entry would be false unless specifically set to published.

I would love to know when this change was done. This could potentially be exposing a lot of things it shouldn't on my sites. Since all the previous history of all netflex-sdk repos got purged with the change to the monorepo. I can't figure it out myself, since I don't have a local copy of the query package.

# Changes 
The first change is that the models now respects publishing status selected by developer above the `autoPublishes` flag. Making one actually able to create an entry where the publishing status is not true, without turning it off.

The second change is to make the entry not automatically publish when changed(not created, changed) without the developer specifically changing the publishing status. Having it on could potentially publish all entries if you want to just bulk change a field. Surely that is an oversight and not intended behaviour