### PR TITLE
Trim redirects

### DIFF
--- a/src/Netflex/Pages/Providers/RouteServiceProvider.php
+++ b/src/Netflex/Pages/Providers/RouteServiceProvider.php
@@ -132,8 +132,8 @@ class RouteServiceProvider extends ServiceProvider
     Collection::make(Redirect::all())
       ->each(function ($redirect) {
         Route::redirect(
-          $redirect->source_url,
-          $redirect->target_url,
+          trim($redirect->source_url),
+          trim($redirect->target_url),
           $redirect->type
         )->name($redirect->id);
       });


### PR DESCRIPTION
Fixes an issue where the content api did not trim some invalid characters and they ruined redirects, while being unremovable in netflex.

This PR trims relevant strings to alleviate this problemo.