### PR TITLE
Fixes serve failing with malformed netflex_editor_proxy

### DIFF
--- a/src/Netflex/Console/Commands/ServeCommand.php
+++ b/src/Netflex/Console/Commands/ServeCommand.php
@@ -175,7 +175,7 @@ class ServeCommand extends Command
       ];
     } else {
       $this->configuration = $this->variable()->value;
-      $this->configuration->proxies = Collection::make($this->configuration->proxies);
+      $this->configuration->proxies = Collection::make($this->configuration->proxies ?? []);
     }
 
     return $this->configuration;


### PR DESCRIPTION
In the event that the proxies field is missing from the `netflex_editor_proxy` variable, serving with ngrok fails.
Either a schema should be applied consistently to all parameters, failing with a descriptive error or repairing the document, or the malformation should be ignored.
This ignores it in mitigating the `Undefined property: stdClass::$proxies` error by applying a fallback with `[]`.