### PR TITLE
Add logic to handle inheritable page permissions

### DIFF
--- a/src/Netflex/Pages/Middleware/GroupAuthentication.php
+++ b/src/Netflex/Pages/Middleware/GroupAuthentication.php
@@ -10,6 +10,8 @@ use Illuminate\Auth\Middleware\Authenticate as Middleware;
 
 class GroupAuthentication extends Middleware
 {
+  const ALL_CUSTOMERS = 99999;
+
   /**
    * Handle an incoming request.
    *
@@ -35,6 +37,10 @@ class GroupAuthentication extends Middleware
 
       $authGroups = collect($page->authgroups);
       $userGroups = collect($request->user()->groups);
+
+      if ($authGroups->contains(static::ALL_CUSTOMERS)) {
+        return $next($request);
+      }
 
       $hasPermission = !!($authGroups->first(function ($authgroup) use ($userGroups) {
         return $userGroups->contains($authgroup);

--- a/src/Netflex/Pages/Page.php
+++ b/src/Netflex/Pages/Page.php
@@ -581,4 +581,23 @@ class Page extends QueryableModel implements Responsable
   {
     return (bool) $children_inherits_permission;
   }
+
+  public function getAuthgroupsAttribute($authgroups)
+  {
+    if ($authgroups) {
+      return array_map('intval', array_values(array_filter(explode(',', $authgroups))));
+    }
+
+    $page = $this->parent;
+
+    if ($page) {
+      do {
+        if (!$page->public && $page->children_inherits_permission) {
+          return $page->authgroups;
+        }
+      } while ($page = $page->parent);
+    }
+
+    return null;
+  }
 }

--- a/src/Netflex/Pages/Page.php
+++ b/src/Netflex/Pages/Page.php
@@ -45,6 +45,7 @@ use Illuminate\Support\Traits\Macroable;
  * @property string|null $lang
  * @property-read string|null $domain
  * @property-read Page|null $parent
+ * @property bool $children_inherits_permission
  */
 class Page extends QueryableModel implements Responsable
 {
@@ -239,6 +240,25 @@ class Page extends QueryableModel implements Responsable
     return !!API::delete('builder/pages/' . $key);
   }
 
+  public function getPublicAttribute($public)
+  {
+    if (!$public) {
+      return false;
+    }
+
+    $page = $this->parent;
+
+    if ($page) {
+      do {
+        if (!$page->public && $page->children_inherits_permission) {
+          return false;
+        }
+      } while ($page = $page->parent);
+    }
+
+    return true;
+  }
+
   /**
    * Retrieves the component names of the given block
    *
@@ -396,7 +416,7 @@ class Page extends QueryableModel implements Responsable
       }))->sortBy('sorting');
     }
 
-    return static::$allItems->map(function ($attributes){
+    return static::$allItems->map(function ($attributes) {
       return (new static)->newFromBuilder($attributes);
     });
   }
@@ -548,11 +568,17 @@ class Page extends QueryableModel implements Responsable
    * @param array|null $config
    * @return object
    */
-  public function getConfigAttribute ($config = []) {
+  public function getConfigAttribute($config = [])
+  {
     $config = collect($config ?? []);
-    
+
     return (object) $config->mapWithKeys(function ($config, $key) {
       return [$key => $config['value'] ?? null];
     })->toArray();
+  }
+
+  public function getChildrenInheritsPermissionAttribute($children_inherits_permission)
+  {
+    return (bool) $children_inherits_permission;
   }
 }


### PR DESCRIPTION
If a parent page specifies group authentication, and has the 'children_inherits_permission' flag set to true, children of that page will recursively inherit this permission unless overriden (same behavior as `lang`)