### PR TITLE
Fixes editor-button icon

### DIFF
--- a/src/Netflex/Pages/resources/views/editor-button.blade.php
+++ b/src/Netflex/Pages/resources/views/editor-button.blade.php
@@ -14,6 +14,6 @@
     @if(isset($slot) && $slot && $slot->isNotEmpty())
         {{ $slot }}
     @else
-        {{ $icon ?? null }} {{ $label ?? null }}
+        {!! $icon ?? null !!} {{ $label ?? null }}
     @endif
 </a>


### PR DESCRIPTION
When providing the `icon` prop to `x-editor-button`, the string `<span class="<icon>"></span>` is escaped and outputted into the button.
This fixes the issue by changing the way its outputted from escaped to straight.