### PR TITLE
Feature/cart item polymorphism

### DIFF
--- a/src/Netflex/Commerce/CartItemCollection.php
+++ b/src/Netflex/Commerce/CartItemCollection.php
@@ -6,5 +6,24 @@ use Netflex\Support\ItemCollection;
 
 class CartItemCollection extends ItemCollection
 {
-  protected static $type = CartItem::class;
+    protected static $type = CartItem::class;
+
+    /**
+     *
+     * Casts the cart item to whatever class is stored in the class property.
+     *
+     * The class put here MUST extend from Netflex\Commerce\CartItem
+     *
+     */
+    protected function generateInstance($item)
+    {
+        try {
+            if (is_array($item['properties']) && ($class = $item['properties']['class'] ?? null) != null) {
+                return $class::factory($item);
+            }
+        } catch (\Exception $e) {
+            return parent::generateInstance($item);
+        }
+        return parent::generateInstance($item);
+    }
 }

--- a/src/Netflex/Commerce/CartItemCollection.php
+++ b/src/Netflex/Commerce/CartItemCollection.php
@@ -18,7 +18,7 @@ class CartItemCollection extends ItemCollection
     protected function generateInstance($item)
     {
         try {
-            if (is_array($item['properties']) && ($class = $item['properties']['class'] ?? null) != null) {
+            if (is_array($item['properties']) && ($class = $item['properties']['_class'] ?? null) != null) {
                 return $class::factory($item);
             }
         } catch (\Exception $e) {

--- a/src/Netflex/Commerce/Traits/API/OrderAddAPI.php
+++ b/src/Netflex/Commerce/Traits/API/OrderAddAPI.php
@@ -16,7 +16,7 @@ trait OrderAddAPI
     public function addCart($item)
     {
         if (!is_array($item) && $item instanceof CartItem) {
-            $item->properties['class'] = get_class($item);
+            $item->properties['_class'] = get_class($item);
         }
 
         if (!$this->id) {

--- a/src/Netflex/Commerce/Traits/API/OrderAddAPI.php
+++ b/src/Netflex/Commerce/Traits/API/OrderAddAPI.php
@@ -4,19 +4,24 @@ namespace Netflex\Commerce\Traits\API;
 
 use Exception;
 use Netflex\API\Facades\API;
+use Netflex\Commerce\CartItem;
 
 trait OrderAddAPI
 {
-  /**
-   * @param array $item
-   * @return static
-   * @throws Exception
-   */
-  public function addCart($item)
-  {
-    if (!$this->id) {
-      $this->save();
-    }
+    /**
+     * @param array|CartItem $item
+     * @return static
+     * @throws Exception
+     */
+    public function addCart($item)
+    {
+        if (!is_array($item) && $item instanceof CartItem) {
+            $item->properties['class'] = get_class($item);
+        }
+
+        if (!$this->id) {
+            $this->save();
+        }
 
     API::post(static::basePath() . $this->id . '/cart', $item);
 

--- a/src/Netflex/Support/ItemCollection.php
+++ b/src/Netflex/Support/ItemCollection.php
@@ -15,6 +15,23 @@ abstract class ItemCollection extends BaseCollection implements JsonSerializable
   /** @var string */
   protected static $type = ReactiveObject::class;
 
+    /**
+     *
+     * Runs the type factory on the item received.
+     *
+     * This function can be overridden to enable simple polymorphism of cart items
+     * in cart.
+     *
+     * If this function is overridden then the developer must ensure data integrity
+     * itself by doing any type checking needed to ensure homogenity amongst members
+     *
+     * @param array|mixed $item Item payload that is to be converted to an object of collection type
+     * @return T something that conforms with static::$type
+     */
+    protected function generateInstance($item) {
+        return static::$type::factory($item);
+    }
+
   /**
    * @param array|null $items = []
    */
@@ -25,7 +42,7 @@ abstract class ItemCollection extends BaseCollection implements JsonSerializable
     if ($items) {
       parent::__construct(array_map(function ($item) {
         if (!($item instanceof static::$type)) {
-          $item = static::$type::factory($item);
+          $item = $this->generateInstance($item);
         }
 
         $item->setParent($this);


### PR DESCRIPTION
Adds polymorphic cart items.

In order to allow us to separate cart items produced by different sub systems in the same order, I've added a simple polymorphic mutator for the CartItemCollection class.


`$order->add(new CartItemExtendingClass(['payload' => 'goes here'])` accepts cart item classes. If a cart item is added instead of just an array as we usually do, then the class of the Cart Item class is stored in the `_class` property on the cart item.

This _class parameter will be used instead of the normal CartItem objects, effectively letting us use different kinds of cart items which we can extend on a project to project basis.
