### PR TITLE
Fixes publishing status issue in NavigationData

### DIFF
--- a/src/Netflex/Pages/NavigationData.php
+++ b/src/Netflex/Pages/NavigationData.php
@@ -5,6 +5,7 @@ namespace Netflex\Pages;
 use Exception;
 use JsonSerializable;
 
+use Netflex\Query\Builder;
 use Netflex\Support\Accessors;
 
 use Illuminate\Support\Collection;
@@ -86,7 +87,7 @@ class NavigationData implements JsonSerializable
 
   /**
    * Resolves navigation data
-   * 
+   *
    * @param int $parent
    * @param string $type
    * @param string $root
@@ -95,11 +96,19 @@ class NavigationData implements JsonSerializable
   public static function get($parent = null, $type = 'nav', $root = null)
   {
     try {
-      $pages = $parent ? Page::model()::find($parent)->children : Page::model()::where('published', true)
-        ->where(function ($query) {
-          return $query->where('parent_id', null)
-            ->orWhere('parent_id', 0);
-        })->get();
+      $pages = $parent
+        ? Page::model()
+          ::find($parent)
+          ->children
+          ->where('published', true)
+        : Page::model()
+          ::where('published', true)
+          ->where(function (Builder $query) {
+            return $query
+              ->where('parent_id', null)
+              ->orWhere('parent_id', 0);
+          })
+          ->get();
 
       $mapPage = function (Page $page) use ($root, $type) {
         $target = $page->nav_target;

--- a/src/Netflex/Pages/Page.php
+++ b/src/Netflex/Pages/Page.php
@@ -46,6 +46,7 @@ use Illuminate\Support\Traits\Macroable;
  * @property-read string|null $domain
  * @property-read Page|null $parent
  * @property bool $children_inherits_permission
+ * @property Collection $children
  */
 class Page extends QueryableModel implements Responsable
 {
@@ -504,10 +505,10 @@ class Page extends QueryableModel implements Responsable
 
   /**
    * Resolves navigation data for this page
-   * 
+   *
    * @param string $type
    * @param string|null $root
-   * 
+   *
    * @return Collection
    */
   public function navigationData($type = 'nav', $root = null)


### PR DESCRIPTION
When parent is provided, there was no check in place to remove unpublished pages.
This adds a published check, and improves readability of $pages declaration in `NavigationData::get`.
Adds $children property to Page docblocks.

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](/netflex-sdk/sdk/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
