### PR TITLE
Fixes deep toArray issue in Builder

### DIFF
--- a/src/Netflex/Query/Builder.php
+++ b/src/Netflex/Query/Builder.php
@@ -390,7 +390,7 @@ class Builder
     if (is_object($value) && $value instanceof Collection) {
       /** @var Collection */
       $value = $value;
-      $value = $value->toArray();
+      $value = $value->all();
     }
 
     if (is_object($value) && $value instanceof QueryableModel) {


### PR DESCRIPTION
If a `Collection` of `QueryableModel` instances is passed to `Builder::where`, if will deeply be converted to arrays, leading to the nested compileWhereQuery call to `throw new InvalidArrayValueException()` as the entry is now an array, and as it's associated, `count()` returns 0.
This fixes the issue by changing the `toArray` call to `all`.

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](/netflex-sdk/sdk/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**: