### PR TITLE
Fixes issue with setting custom timestamp on consent assignment

### DIFF
--- a/src/Netflex/Customers/ConsentAssignment.php
+++ b/src/Netflex/Customers/ConsentAssignment.php
@@ -127,7 +127,7 @@ class ConsentAssignment implements JsonSerializable, Jsonable
         $ip = null;
 
         if (isset($options['timestamp'])) {
-            $timestamp = ($timestamp instanceof Carbon) ? $timestamp->toDateTimeString() : $timestamp;
+            $timestamp = ($options['timestamp'] instanceof Carbon) ? $options['timestamp']->toDateTimeString() : $options['timestamp'];
         }
 
         if (array_key_exists('ip', $options)) {


### PR DESCRIPTION
Current implementation will always return current datetime as $options is not referred.