### PR TITLE
Speed up config variable replacement in order to allow us to use variable based config in boot methods.

### DIFF
--- a/src/Netflex/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Netflex/Foundation/Providers/FoundationServiceProvider.php
@@ -2,23 +2,33 @@
 
 namespace Netflex\Foundation\Providers;
 
+use Illuminate\Config\Repository;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 
 class FoundationServiceProvider extends ServiceProvider
-{    
-    public function boot()
+{
+    public function register()
     {
-        Event::listen('bootstrapped: Illuminate\Foundation\Bootstrap\BootProviders', function () {
-            foreach (Arr::dot(Config::all()) as $key => $value) {
-                if (is_string($value)) {
-                    if (preg_match('/^#(\w+)#$/', $value, $matches)) {
-                        Config::set($key, variable($matches[1]));
-                    }
-                }
-            }
+        app('events')->listen("bootstrapping: Illuminate\Foundation\Bootstrap\BootProviders", function() {
+            $old = app('config')->all();
+            $new = new Repository($this->replace_variables($old));
+            unset($old);
+            $this->app->singleton('config', fn() => $new);
         });
+    }
+
+    private function replace_variables($config, $i = 0) {
+        if(is_array($config)) {
+            return collect($config)
+                ->map(fn($value) => $this->replace_variables($value, $i + 1))
+                ->toArray();
+        } if(is_string($config) && strlen($config) >= 3 && $config[0] === "#" && $config[strlen($config) - 1] === "#") {
+            return variable(substr($config, 1, -1));
+        } else {
+            return $config;
+        }
     }
 }

--- a/src/Netflex/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Netflex/Foundation/Providers/FoundationServiceProvider.php
@@ -14,9 +14,7 @@ class FoundationServiceProvider extends ServiceProvider
     {
         app('events')->listen("bootstrapping: Illuminate\Foundation\Bootstrap\BootProviders", function() {
             $old = app('config')->all();
-            $new = new Repository($this->replace_variables($old));
-            unset($old);
-            $this->app->singleton('config', fn() => $new);
+            $this->app->instance('config', new Repository($this->replace_variables($old)));
         });
     }
 

--- a/src/Netflex/Foundation/Variable.php
+++ b/src/Netflex/Foundation/Variable.php
@@ -59,8 +59,8 @@ class Variable extends ReactiveObject
    */
   public static function all()
   {
-    $templates = Cache::rememberForever('variables', function () {
-      return API::get('foundation/variables');
+    $templates = app('cache')->rememberForever('variables', function () {
+      return app('api.client')->get('foundation/variables');
     });
 
     return collect($templates)->map(function ($content) {
@@ -74,7 +74,10 @@ class Variable extends ReactiveObject
    */
   public static function retrieve($alias)
   {
-    if (Facade::getFacadeApplication() && App::isBooted()) {
+      $services_uncached = app()->has('api.client') && app()->has('cache');
+      $services_cached = app()->has('cache') && app('cache')->has('variables');
+
+    if ($services_uncached || $services_cached) {
       return static::all()->first(function ($content) use ($alias) {
         return $content->alias === $alias;
       });


### PR DESCRIPTION
Its not possible to us to use config entries that use `variable()` (or `variable() calls directly`) in ServiceProviders, which would be very useful during the bootstrap process.

The config resolver would only resolve variables after the app was booted which was unnecessarily late.
I've rewritten this check to only check that it has the two components it needs; the `api.client` and `cache`.

This also rewrites the previous logic that replaced the placeholder config values with a new one that only traverses the config tree once instead of once per variable.

We now listen to the pre-boot event `bootstrapping: Illuminate\Foundation\Bootstrap\BootProviders` which runs directly before boot is run on service providers.

This ensures we can now use variable configs in all boot methods

NF-137