### PR TITLE
Fix Builder::random crashing if the query it randoms on produces no results

### DIFF
--- a/src/Netflex/Query/Builder.php
+++ b/src/Netflex/Query/Builder.php
@@ -1049,7 +1049,9 @@ class Builder
     $orderBy = $this->orderBy;
     $this->orderBy = [];
 
-    $result = $this->where('id', $random)->get();
+    $result = sizeof($random) > 0
+        ? $this->where('id', $random)->get()
+        : collect();
 
     $this->query = $query;
     $this->size = $size;


### PR DESCRIPTION
The random function performs an id search then shuffles and refetches random ids up to the selected amount.

However if the initial id query returns no results, the system tries to perform a new search for ids where the list is empty.

In this case the results should be an empty list. Therefore we just return an empty collection instead.
