### PR TITLE
Add trait that enables casting matrixes to lists of models instead of arrays

### DIFF
--- a/src/Netflex/Structures/Casts/AsMatrix.php
+++ b/src/Netflex/Structures/Casts/AsMatrix.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Netflex\Structure\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Contracts\Support\Arrayable;
+use Netflex\Structure\Matrix\BaseMatrixEntry;
+use Netflex\Structure\Matrix\MatrixEntry;
+
+class AsMatrix implements Castable
+{
+    public static function castUsing(array $attributes)
+    {
+        return new class implements CastsAttributes {
+
+            public function get($model, string $key, $value, array $attributes)
+            {
+                $default = ($model->matrix ?? [])['default'] ?? BaseMatrixEntry::class;
+                $builder = new MatrixBuilder($model, $value, $default);
+                $types = ($model->matrix ?? [])[$key] ?? [];
+
+                foreach ($types as $key => $value) {
+                    $builder->resolve($key, $value);
+                }
+
+                return $builder->render();
+            }
+
+            public function set($model, string $key, $value, array $attributes)
+            {
+                return $value->map(
+                    fn(MatrixEntry $mi) => array_merge($mi->getAttributes(), ['type' => $mi->getMatrixType()])
+                )->toArray();
+            }
+        };
+    }
+}

--- a/src/Netflex/Structures/Matrix/BaseMatrixEntry.php
+++ b/src/Netflex/Structures/Matrix/BaseMatrixEntry.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Netflex\Structure\Matrix;
+
+/**
+ * @property string $type
+ */
+class BaseMatrixEntry extends MatrixEntry
+{
+
+    public function getMatrixType(): string {
+        return $this->type;
+    }
+
+    public function setRawAttributes(array $attributes, $sync = false)
+    {
+        $renamedAttributes = [];
+        foreach ($attributes as $key => $value) {
+            $renamedAttributes[($this->renames ?? [])[$key] ?? $key] = $value;
+        }
+
+        return parent::setRawAttributes($renamedAttributes, $sync);
+    }
+}

--- a/src/Netflex/Structures/Matrix/MatrixBuilder.php
+++ b/src/Netflex/Structures/Matrix/MatrixBuilder.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Netflex\Structure\Matrix;
+
+use Illuminate\Support\Collection;
+use Netflex\Structure\Model;
+
+class MatrixBuilder
+{
+    private Model $owner;
+    private $items;
+
+    public function __construct($owner, $items = [], $default = BaseMatrixEntry::class)
+    {
+        $this->owner = $owner;
+        $this->items = $items;
+        $this->resolvers['default'] = $default;
+    }
+
+    private array $resolvers = [];
+
+    public function resolve(string $type, string $class): self
+    {
+        $this->resolvers[$type] = $class;
+        return $this;
+    }
+
+
+    private function getResolver(string $type): Model
+    {
+        $class = ($this->resolvers[$type] ?? $this->resolvers['default']);
+        return new $class;
+    }
+
+    public function render(): Collection
+    {
+        $data = collect($this->items)
+            ->map(fn(array $data) => $this->getResolver($data['type'])->newFromBuilder($data, true));
+        return $data;
+    }
+
+
+}

--- a/src/Netflex/Structures/Matrix/MatrixEntry.php
+++ b/src/Netflex/Structures/Matrix/MatrixEntry.php
@@ -1,0 +1,9 @@
+<?php
+namespace Netflex\Structure\Matrix;
+
+use Netflex\Structure\Model;
+use Netflex\Structure\Structure;
+
+abstract class MatrixEntry extends Model {
+    abstract public function getMatrixType(): string;
+}

--- a/src/Netflex/Structures/Traits/MatrixCasts.php
+++ b/src/Netflex/Structures/Traits/MatrixCasts.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Netflex\Structure\Traits;
+
+use Netflex\Structure\AsMatrix;
+
+trait MatrixCasts
+{
+    public static function bootMatrixCasts()
+    {
+        static::retrieved(fn($model) => $model->__resolveMatrixTypes());
+    }
+
+    private function __resolveMatrixTypes()
+    {
+        foreach ($this->getCasts() as $key => $value) {
+            if ($value == 'matrix') {
+                $this->mergeCasts([$key => AsMatrix::class]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR is currently a draft for a trait that enables us to automatically cast matrixes to object collections instead of an array of associative arrays.

```php
<?php

class MyModel extends Model {

// Enables the feature
use Netflex\Structure\MatrixCasts;

// Declare which fields you want to cast to matrix
protected $casts => [
   'field_name' => 'matrix'
];

// If no options are set, a default BaseModel with no implemented features is 
// returned for each matrix entry,
public $matrix = [
   // You can set your own default model globally if you want to
   'default' => MyMatrixModel::class,
   'some_matrix_field' => [
     // You can set a default model per field also
     'default' => MyOtherDefaultMatrixModel::class,
     // You can also set a different model per matrix entry type, if you want to resolve them individually
     'image' => MyImageMatrixModel::class,
   ]
];


