### PR TITLE
add handling of missing page controller

### DIFF
--- a/src/Netflex/Pages/Controllers/ControllerNotImplementedController.php
+++ b/src/Netflex/Pages/Controllers/ControllerNotImplementedController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Netflex\Pages\Controllers;
+
+use Netflex\Pages\Exceptions\ControllerNotImplementedException;
+use Netflex\Pages\Providers\RouteServiceProvider;
+use ReflectionClass;
+
+class ControllerNotImplementedController extends Controller
+{
+  protected string $namespace;
+
+  protected $routes = [
+    [
+      'url' => '/',
+      'action' => 'index',
+      'methods' => ['GET'],
+      'name' => 'index',
+    ],
+  ];
+
+  /** @throws ControllerNotImplementedException */
+  public function index ()
+  {
+    $page = current_page();
+
+    $routeServiceProvider = new RouteServiceProvider(app());
+    $reflectionClass = new ReflectionClass($routeServiceProvider);
+    $namespaceProp = $reflectionClass->getProperty('namespace');
+    $namespaceProp->setAccessible(true);
+    $namespace = $namespaceProp->getValue($routeServiceProvider);
+
+    // We want to provide a stacktrace while in debug, but just a generic 404 when in production.
+    if (app()->environment() !== 'master') {
+      throw new ControllerNotImplementedException($namespace, $page->template->controller);
+    } else {
+      abort(404);
+    }
+  }
+}

--- a/src/Netflex/Pages/Exceptions/ControllerNotImplementedException.php
+++ b/src/Netflex/Pages/Exceptions/ControllerNotImplementedException.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Netflex\Pages\Exceptions;
+
+use Exception;
+use Facade\IgnitionContracts\BaseSolution;
+use Facade\IgnitionContracts\ProvidesSolution;
+use Facade\IgnitionContracts\Solution;
+
+class ControllerNotImplementedException extends Exception implements ProvidesSolution
+{
+  protected string $className;
+  protected string $namespace;
+  protected string $class;
+
+  public function __construct (string $namespace, string $className)
+  {
+    $this->className = $className;
+    $this->namespace = $namespace;
+    $this->class = "\\{$namespace}\\{$className}";
+
+    parent::__construct('Controller ' . $this->class . ' not implemented');
+  }
+
+  public function getSolution (): Solution
+  {
+    return BaseSolution::create('Controller ' . $this->class . ' not implemented')
+      ->setSolutionDescription(
+        "Implement missing page controller\n\n`§ php artisan make:controller {$this->className}`"
+      );
+  }
+}


### PR DESCRIPTION
When building the page routes, each page's controller is invoked.
In instances where a developer has registered a template with a controller in Netflex, and assigned it to a page, but not deployed the controller implementation, the page throws with a 500 everywhere.
This adds a fallback controller in such cases, which lets the route registration complete, and let's us show an error when the route is loaded instead.