### PR TITLE
Add option to subtract from the max-width media query on srcsets

### DIFF
--- a/src/Netflex/Pages/Components/Picture.php
+++ b/src/Netflex/Pages/Components/Picture.php
@@ -201,6 +201,7 @@ class Picture extends Component
       $srcSet = [
         'breakpoint' => $breakpoint,
         'maxWidth' => $preset->maxWidth,
+        'mqMaxWidth' => $preset->maxWidth - Config::get('media.options.breakpoints.media_query_max_width_subtract', 0),
         'paths' => []
       ];
 

--- a/src/Netflex/Pages/config/media.php
+++ b/src/Netflex/Pages/config/media.php
@@ -13,7 +13,10 @@ return [
     'options' => [
         'image' => [
             'setWidthAndHeightAttributes' => false,
-        ]
+        ],
+        'breakpoints' => [
+            'media_query_max_width_subtract' => 0,
+        ],
     ],
 
     /*

--- a/src/Netflex/Pages/resources/views/background-image.blade.php
+++ b/src/Netflex/Pages/resources/views/background-image.blade.php
@@ -35,7 +35,7 @@ $stack = $attributes->get('stack') ? $attributes->get('stack') : null;
 
   @foreach ($srcSets as $srcSet)
     @isset($srcSet['sources']['1x'])
-      @media (max-width: {{ $srcSet['maxWidth'] }}px) {
+      @media (max-width: {{ $srcSet['mqMaxWidth'] }}px) {
         .{{ $bgCss }} {
           background-image: url({!! $srcSet['sources']['1x'] !!});
         }
@@ -47,11 +47,11 @@ $stack = $attributes->get('stack') ? $attributes->get('stack') : null;
     @foreach($srcSet['sources'] as $resolution => $src)
       @if($resolution !== '1x')
         @media
-        (-webkit-min-device-pixel-ratio: {{ intval($resolution) }}) and (max-width: {{ $srcSet['maxWidth'] }}px),
-        (min--moz-device-pixel-ratio: {{ intval($resolution) }}) and (max-width: {{ $srcSet['maxWidth'] }}px),
-        (-o-min-device-pixel-ratio: {{ intval($resolution) }}/1) and (max-width: {{ $srcSet['maxWidth'] }}px),
-        (min-device-pixel-ratio: {{ intval($resolution) }}) and (max-width: {{ $srcSet['maxWidth'] }}px),
-        (min-resolution: {{ intval($resolution) }}dppx) and (max-width: {{ $srcSet['maxWidth'] }}px)
+        (-webkit-min-device-pixel-ratio: {{ intval($resolution) }}) and (max-width: {{ $srcSet['mqMaxWidth'] }}px),
+        (min--moz-device-pixel-ratio: {{ intval($resolution) }}) and (max-width: {{ $srcSet['mqMaxWidth'] }}px),
+        (-o-min-device-pixel-ratio: {{ intval($resolution) }}/1) and (max-width: {{ $srcSet['mqMaxWidth'] }}px),
+        (min-device-pixel-ratio: {{ intval($resolution) }}) and (max-width: {{ $srcSet['mqMaxWidth'] }}px),
+        (min-resolution: {{ intval($resolution) }}dppx) and (max-width: {{ $srcSet['mqMaxWidth'] }}px)
         {
           .{{ $bgCss }} {
             background-image: url({!! $src !!});

--- a/src/Netflex/Pages/resources/views/picture.blade.php
+++ b/src/Netflex/Pages/resources/views/picture.blade.php
@@ -1,14 +1,14 @@
 @if($inline && current_mode() === 'edit')
 <picture {{ $attributes->merge(['class' => $pictureClass]) }}>
   @foreach ($srcSets as $srcSet)
-    <source srcset="{{ $srcSet['paths'] }}" media="(max-width: {{ $srcSet['maxWidth'] }}px)">
+    <source srcset="{{ $srcSet['paths'] }}" media="(max-width: {{ $srcSet['mqMaxWidth'] }}px)">
   @endforeach
   <img {{ $attributes->only('class')->merge(['class' => $imageClass . ' find-image']) }} src="{{ $defaultSrc }}" {{ $attributes->except('id')->merge($editorSettings()) }}>
 </picture>
 @else
 <picture {{ $attributes->merge(['class' => $pictureClass]) }}>
   @foreach ($srcSets as $srcSet)
-    <source srcset="{{ $srcSet['paths'] }}" media="(max-width: {{ $srcSet['maxWidth'] }}px)">
+    <source srcset="{{ $srcSet['paths'] }}" media="(max-width: {{ $srcSet['mqMaxWidth'] }}px)">
   @endforeach
   <img class="{{ collect([$attributes->get('class'), $imageClass])->filter()->join(' ') }}" src="{{ $defaultSrc }}" srcset="{{ $defaultSrcSet }}" title="{{ $title }}" alt="{{ $alt }}" loading="{{ $loading }}">
 </picture>


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  Feature


* **What is the current behavior?** (You can also link to an open issue here)
  Srcsets generated by the Picture and BackgroundImage components will generate media queries with max-width equal to the width of the media preset breakpoint.


* **What is the new behavior (if this is a feature change)?**
  If the configuration key `media.options.breakpoints.media_query_max_width_subtract` is set, the value of said config key will be subtracted from the max-width in the generated media queries. This is useful for matching the responsive images to the more commonly used for layout min-width media queries. Without subtracting from the max-width, the breakpoint will end up overlapping the min-width breakpoints with the same value.
  
  Setting this option to `0.02` will match Bootstrap's approach to [max-width breakpoints](https://getbootstrap.com/docs/5.3/layout/breakpoints/#max-width). This will allow you to set the breakpoints to match Bootstrap's breakpoints:
  
  ```php
  'breakpoints' => [
      'xxs' => 376, // not actually part of Bootstrap, but still useful
      'xs' => 480,
      'sm' => 576,
      'md' => 768,
      'lg' => 992,
      'xl' => 1200,
      'xxl' => 1400,
  ],
  ```

  This will generate media queries like `@media (max-width: 575.98px) { ... }` and therefore not overlap with the corresponding min-width media query `@media (min-width: 576px) { ... }`.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  No