### PR TITLE
Feature/deserialize jwt payload wsi 1

### DIFF
--- a/src/Netflex/Pages/Extension.php
+++ b/src/Netflex/Pages/Extension.php
@@ -15,10 +15,17 @@ use Netflex\Pages\Exceptions\NotImplementedException;
 abstract class Extension implements Renderable, Responsable
 {
   use Macroable;
-  
+
   protected $view;
   protected $name;
   protected $data = [];
+
+  public function __construct(array $data)
+  {
+    $this->data = $data;
+    $this->view = $data['view'] ?? null;
+    $this->name = $data['name'] ?? null;
+  }
 
   public function handle(Request $request)
   {

--- a/src/Netflex/Pages/JwtPayload.php
+++ b/src/Netflex/Pages/JwtPayload.php
@@ -13,7 +13,6 @@ use Illuminate\Support\Traits\Macroable;
  * @property-read int|null $page_id
  * @property-read int|null $revision_id
  * @property-read string|null $edit_tools
- * @property-read string|null $edit_tools
  * @property-read string $domain
  * @property-read int $uid
  * @property-read int $iat
@@ -35,5 +34,9 @@ class JwtPayload
 
     public function getModeAttribute ($mode = null) {
         return $mode ?? 'live';
+    }
+
+    public function getAttributes(): array {
+      return $this->attributes;
     }
 }

--- a/src/Netflex/Pages/Providers/RouteServiceProvider.php
+++ b/src/Netflex/Pages/Providers/RouteServiceProvider.php
@@ -259,8 +259,9 @@ class RouteServiceProvider extends ServiceProvider
 
   protected function handleExtension(Request $request, $payload)
   {
+    /** @var JwtPayload $payload */
     if ($alias = $payload->view) {
-      if ($extension = resolve_extension($alias, json_decode(json_encode($payload), true))) {
+      if ($extension = resolve_extension($alias, json_decode(json_encode($payload->getAttributes()), true))) {
         return $extension->handle($request);
       }
     }


### PR DESCRIPTION
This PR fixes a bug in Extensions where the JwtPayload was deserialized incorrectly and is not available to the handle method, as `$this->data` is null.

This also fixes a bug with deserialization of JwtPayload as only serializes the `modified` key and not the wanted attributes. I have added a getter for the attributes so they can selectively be json encoded where necessary as to not prevent us from implementing json serialization for the entire token later, if necessary.