### PR TITLE
Set current_newsletter when attempting to render, if it is not set already

### DIFF
--- a/src/Netflex/Newsletters/Newsletter.php
+++ b/src/Netflex/Newsletters/Newsletter.php
@@ -278,6 +278,9 @@ class Newsletter extends QueryableModel
    * @return HtmlString
    */
   public function render(): HtmlString {
+    if(!current_newsletter()) {
+      current_newsletter($this);
+    }
     if ($page = $this->page) {
         App::setLocale($page->lang ?? App::getLocale());
         return new HtmlString($page->toResponse(request()));


### PR DESCRIPTION
`current_newsletter()` should always be the newsletter that is rendering(unless you're doing something spicy).

To ensure that it is always something else than null, we check it before rendering and set it to the newsletter that is attempted rendered, if it is not already set.