### PR TITLE
Improve dataloading

### DIFF
--- a/src/Netflex/Foundation/GlobalContent.php
+++ b/src/Netflex/Foundation/GlobalContent.php
@@ -23,10 +23,10 @@ use Illuminate\Support\Facades\Cache;
 class GlobalContent extends ReactiveObject
 {
   /**
-   * @param array $content
+   * @param array $globals
    * @return Collection
    */
-  public function getGlobalsAttribute($globals = [])
+  public function getGlobalsAttribute($globals = []): Collection
   {
     return collect($globals);
   }

--- a/src/Netflex/Foundation/GlobalContent.php
+++ b/src/Netflex/Foundation/GlobalContent.php
@@ -36,12 +36,14 @@ class GlobalContent extends ReactiveObject
    */
   public static function all()
   {
-    $content = Cache::rememberForever('statics', function () {
-      return API::get('foundation/globals');
-    });
+    return once(function () {
+      $content = Cache::rememberForever('statics', function () {
+        return API::get('foundation/globals');
+      });
 
-    return collect($content)->map(function ($content) {
-      return new static($content);
+      return collect($content)->map(function ($content) {
+        return new static($content);
+      });
     });
   }
 

--- a/src/Netflex/Foundation/Template.php
+++ b/src/Netflex/Foundation/Template.php
@@ -85,7 +85,7 @@ class Template extends ReactiveObject implements Responsable
       static::$templates = Cache::rememberForever('templates', function () {
         $data = API::get('foundation/templates');
 
-        return static::$templates = collect($data)->map(function ($template) {
+        return collect($data)->map(function ($template) {
           return new static($template);
         })->keyBy('id');
       });

--- a/src/Netflex/Foundation/Template.php
+++ b/src/Netflex/Foundation/Template.php
@@ -2,13 +2,12 @@
 
 namespace Netflex\Foundation;
 
+use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\View;
 use Netflex\API\Facades\API;
 use Netflex\Support\ReactiveObject;
-
-use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\View;
-use Illuminate\Support\Facades\Cache;
-use Illuminate\Contracts\Support\Responsable;
 
 class Template extends ReactiveObject implements Responsable
 {
@@ -35,19 +34,21 @@ class Template extends ReactiveObject implements Responsable
   }
 
   /**
-   * @param string|null $alias 
+   * @param string|null $alias
    * @return string|null
    */
-  public function getAliasAttribute ($alias) {
+  public function getAliasAttribute($alias)
+  {
     if ($alias) {
       return str_replace('/', '.', $alias);
     }
   }
 
   /**
-   * @param string|null $alias 
+   * @param string|null $alias
    */
-  public function setAliasAttribute ($alias) {
+  public function setAliasAttribute($alias)
+  {
     if ($alias) {
       $alias = str_replace('.', '/', $alias);
     }
@@ -55,7 +56,8 @@ class Template extends ReactiveObject implements Responsable
     return $this->attributes['alias'] = $alias;
   }
 
-  public function getViewAttribute () {
+  public function getViewAttribute()
+  {
     if ($this->type === 'newsletter') {
       return "newsletters.{$this->alias}";
     }
@@ -67,36 +69,45 @@ class Template extends ReactiveObject implements Responsable
    * Create an HTTP response that represents the object.
    *
    * @param array $variables
-   * @return \Symfony\Component\HttpFoundation\Response
+   * @return \Symfony\Component\HttpFoundation\Response|string
    */
   public function toResponse($variables = [])
   {
-    return View::make($this->view, $variables)
-      ->render();
+    return View::make($this->view, $variables)->render();
+  }
+
+
+  static $templates = null;
+
+  private static function getTemplates(): Collection
+  {
+    if(!static::$templates) {
+      static::$templates = Cache::rememberForever('templates', function () {
+        $data = API::get('foundation/templates');
+
+        return static::$templates = collect($data)->map(function ($template) {
+          return new static($template);
+        })->keyBy('id');
+      });
+    }
+
+    return static::$templates;
   }
 
   /**
-   * @return static[]
+   * @return static[]|Collection
    */
   public static function all()
   {
-    $templates = Cache::rememberForever('templates', function () {
-      return API::get('foundation/templates');
-    });
-
-    return collect($templates)->map(function ($template) {
-      return new static($template);
-    });
+    return static::getTemplates()->values();
   }
 
-    /**
+  /**
    * @param int $id
    * @return static|void
    */
   public static function retrieve($id)
   {
-    return static::all()->first(function ($template) use ($id) {
-      return $template->id === $id;
-    });
+    return static::getTemplates()[$id] ?? null;
   }
 }

--- a/src/Netflex/Foundation/Variable.php
+++ b/src/Netflex/Foundation/Variable.php
@@ -2,15 +2,9 @@
 
 namespace Netflex\Foundation;
 
-use Netflex\API\Facades\API;
-
-use Netflex\Support\Retrievable;
-use Netflex\Support\ReactiveObject;
-
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\App;
-use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Facade;
+use Netflex\Support\ReactiveObject;
+use Netflex\Support\Retrievable;
 
 class Variable extends ReactiveObject
 {
@@ -42,7 +36,7 @@ class Variable extends ReactiveObject
   {
     switch ($this->format) {
       case 'boolean':
-        return (bool) (int) $value;
+        return (bool)(int)$value;
       case 'json':
         if (is_string($value)) {
           return json_decode($value);
@@ -68,16 +62,18 @@ class Variable extends ReactiveObject
     });
   }
 
+
   /**
    * @param string $alias
    * @return static|void
    */
   public static function retrieve($alias)
   {
-      $services_uncached = app()->has('api.client') && app()->has('cache');
-      $services_cached = app()->has('cache') && app('cache')->has('variables');
+    static $loaded = false;
+    $services_uncached = $loaded || app()->has('api.client') && app()->has('cache');
 
-    if ($services_uncached || $services_cached) {
+    if ($services_uncached) {
+      $loaded = true;
       return static::all()->first(function ($content) use ($alias) {
         return $content->alias === $alias;
       });

--- a/src/Netflex/Foundation/Variable.php
+++ b/src/Netflex/Foundation/Variable.php
@@ -65,6 +65,8 @@ class Variable extends ReactiveObject
   }
 
 
+
+  static $data = null;
   /**
    * @param string $alias
    * @return static|void
@@ -76,9 +78,8 @@ class Variable extends ReactiveObject
 
     if ($services_uncached) {
       $loaded = true;
-      return static::all()->first(function ($content) use ($alias) {
-        return $content->alias === $alias;
-      });
+      static::$data ??= static::all()->keyBy('alias');
+      return static::$data[$alias] ?? null;
     }
 
     return new static(['alias' => $alias, 'value' => '#' . $alias . '#']);

--- a/src/Netflex/Foundation/Variable.php
+++ b/src/Netflex/Foundation/Variable.php
@@ -53,12 +53,14 @@ class Variable extends ReactiveObject
    */
   public static function all()
   {
-    $templates = app('cache')->rememberForever('variables', function () {
-      return app('api.client')->get('foundation/variables');
-    });
+    return once(function () {
+      $templates = app('cache')->rememberForever('variables', function () {
+        return app('api.client')->get('foundation/variables');
+      });
 
-    return collect($templates)->map(function ($content) {
-      return new static($content);
+      return collect($templates)->map(function ($content) {
+        return new static($content);
+      });
     });
   }
 

--- a/src/Netflex/Pages/AbstractPage.php
+++ b/src/Netflex/Pages/AbstractPage.php
@@ -400,18 +400,24 @@ abstract class AbstractPage extends QueryableModel implements Responsable
       ->values();
   }
 
-  private static function getPages(): Collection {
+  private static function getPages(): Collection
+  {
     if (!static::$allItems) {
       /** @var Collection */
-      static::$allItems = collect(Cache::rememberForever('pages', function () {
-        return API::get('builder/pages/content', true);
-      }))->sortBy('sorting')->map(function ($attributes) {
+      $data = Cache::rememberForever('pages', function () {
+        return collect(API::get('builder/pages/content', true))
+          ->sortBy('sorting')
+          ->keyBy('id');
+      });
+
+      static::$allItems = $data->map(function ($attributes) {
         return (new static)->newFromBuilder($attributes);
-      })->keyBy(fn(AbstractPage $page) => $page->getKey());
+      });
     }
 
     return static::$allItems;
   }
+
   /**
    * Retrieves all instances
    *

--- a/src/Netflex/Pages/AbstractPage.php
+++ b/src/Netflex/Pages/AbstractPage.php
@@ -2,26 +2,21 @@
 
 namespace Netflex\Pages;
 
-use Throwable;
-
+use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\LazyCollection;
+use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Macroable;
 use Netflex\API\Facades\API;
-
-use Netflex\Query\Builder;
-use Netflex\Query\QueryableModel;
-
 use Netflex\Foundation\Template;
-
 use Netflex\Pages\Traits\CastsDefaultFields;
 use Netflex\Pages\Traits\HidesDefaultFields;
-
-use Illuminate\Support\Str;
-use Illuminate\Support\LazyCollection;
-use Illuminate\Support\Collection;
-use Illuminate\Contracts\Support\Responsable;
-use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\App;
-use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Traits\Macroable;
+use Netflex\Query\Builder;
+use Netflex\Query\QueryableModel;
+use Throwable;
 
 /**
  * @property int $id
@@ -209,9 +204,9 @@ abstract class AbstractPage extends QueryableModel implements Responsable
   /**
    * Inserts a new record, and returns its id
    *
-   * @property int|null $relationId
-   * @property array $attributes
    * @return mixed
+   * @property array $attributes
+   * @property int|null $relationId
    */
   protected function performInsertRequest(?int $relationId = null, array $attributes = [])
   {
@@ -275,7 +270,7 @@ abstract class AbstractPage extends QueryableModel implements Responsable
     $blocks = $this->content->filter(function ($content) use ($area) {
       return $content->published && $content->area === $area;
     })->map(function ($block) {
-      if ($template = Template::retrieve((int) $block->text)) {
+      if ($template = Template::retrieve((int)$block->text)) {
         return [$template->alias, $block->title ? $block->title : null];
       };
     });
@@ -288,7 +283,7 @@ abstract class AbstractPage extends QueryableModel implements Responsable
    */
   public function hasTemplate()
   {
-    return (bool) ($this->attributes['template'] ?? null)
+    return (bool)($this->attributes['template'] ?? null)
       && is_numeric($this->attributes['template']);
   }
 
@@ -342,7 +337,7 @@ abstract class AbstractPage extends QueryableModel implements Responsable
   public function getTemplateAttribute($template = null)
   {
     if ($this->hasTemplate()) {
-      return Template::retrieve((int) $template);
+      return Template::retrieve((int)$template);
     }
   }
 
@@ -362,7 +357,7 @@ abstract class AbstractPage extends QueryableModel implements Responsable
   /**
    * Create an HTTP response that represents the object.
    *
-   * @param  \Illuminate\Http\Request $request
+   * @param \Illuminate\Http\Request $request
    * @return \Symfony\Component\HttpFoundation\Response
    */
   public function toResponse($request)
@@ -388,7 +383,7 @@ abstract class AbstractPage extends QueryableModel implements Responsable
    */
   public function getParentAttribute()
   {
-    return static::find((int) $this->parent_id);
+    return static::find((int)$this->parent_id);
   }
 
   /**
@@ -400,11 +395,23 @@ abstract class AbstractPage extends QueryableModel implements Responsable
   {
     return static::all()
       ->filter(function ($page) {
-        return (int) $page->parent_id === (int) $this->id;
+        return (int)$page->parent_id === (int)$this->id;
       })
       ->values();
   }
 
+  private static function getPages(): Collection {
+    if (!static::$allItems) {
+      /** @var Collection */
+      static::$allItems = collect(Cache::rememberForever('pages', function () {
+        return API::get('builder/pages/content', true);
+      }))->sortBy('sorting')->map(function ($attributes) {
+        return (new static)->newFromBuilder($attributes);
+      })->keyBy(fn(AbstractPage $page) => $page->getKey());
+    }
+
+    return static::$allItems;
+  }
   /**
    * Retrieves all instances
    *
@@ -414,16 +421,8 @@ abstract class AbstractPage extends QueryableModel implements Responsable
    */
   public static function all()
   {
-    if (!static::$allItems) {
-      /** @var Collection */
-      static::$allItems = collect(Cache::rememberForever('pages', function () {
-        return API::get('builder/pages/content', true);
-      }))->sortBy('sorting');
-    }
 
-    return static::$allItems->map(function ($attributes) {
-      return (new static)->newFromBuilder($attributes);
-    });
+    return static::getPages()->values();
   }
 
   /**
@@ -436,10 +435,7 @@ abstract class AbstractPage extends QueryableModel implements Responsable
    */
   public static function find($id)
   {
-    return static::all()
-      ->first(function (Page $page) use ($id) {
-        return $page->getKey() === (int) $id;
-      });
+    return static::getPages()[$id] ?? null;
   }
 
 
@@ -577,14 +573,14 @@ abstract class AbstractPage extends QueryableModel implements Responsable
   {
     $config = collect($config ?? []);
 
-    return (object) $config->mapWithKeys(function ($config, $key) {
+    return (object)$config->mapWithKeys(function ($config, $key) {
       return [$key => $config['value'] ?? null];
     })->toArray();
   }
 
   public function getChildrenInheritsPermissionAttribute($children_inherits_permission)
   {
-    return (bool) $children_inherits_permission;
+    return (bool)$children_inherits_permission;
   }
 
   public function getAuthgroupsAttribute($authgroups)

--- a/src/Netflex/Pages/Components/Nav.php
+++ b/src/Netflex/Pages/Components/Nav.php
@@ -31,7 +31,7 @@ class Nav extends Component
    * @param string|null $aClass
    * @param bool $showTitle
    */
-  public function __construct($parent = null, $levels = null, $type = 'nav', $root = null, $activeClass = null, $dropdownClass = 'dropdown-container', $liClass = null, $aClass = null, $showTitle = false)
+  public function __construct($parent = null, $levels = null, $type = 'nav', $root = null, $activeClass = null, $dropdownClass = 'dropdown-container', $liClass = null, $aClass = null, $showTitle = false, $children = null)
   {
     if ($parent instanceof Page) {
       $parent = $parent->id;
@@ -44,7 +44,7 @@ class Nav extends Component
     $this->dropdownClass = $dropdownClass;
     $this->liClass = $liClass;
     $this->aClass = $aClass;
-    $this->children = NavigationData::get($parent, $type, $root);
+    $this->children = $children ?? NavigationData::get($parent, $type, $root);
     $this->showTitle = $showTitle;
   }
 

--- a/src/Netflex/Pages/Page.php
+++ b/src/Netflex/Pages/Page.php
@@ -6,23 +6,25 @@ use Netflex\Pages\AbstractPage;
 
 class Page extends AbstractPage
 {
-    protected static function makeQueryBuilder($appends = [])
-    {
-        $builder = parent::makeQueryBuilder($appends);
+  protected static function makeQueryBuilder($appends = [])
+  {
+    $builder = parent::makeQueryBuilder($appends);
 
-        return $builder->where('type', static::TYPE_PAGE);
-    }
+    return $builder->where('type', static::TYPE_PAGE);
+  }
 
-    public static function all()
-    {
-        return parent::all()
-            ->whereIn('type', [
-                static::TYPE_DOMAIN,
-                static::TYPE_EXTERNAL,
-                static::TYPE_FOLDER,
-                static::TYPE_INTERNAL,
-                static::TYPE_PAGE,
-            ])
-            ->values();
-    }
+  public static function all()
+  {
+    return once(function () {
+      return parent::all()
+        ->whereIn('type', [
+          static::TYPE_DOMAIN,
+          static::TYPE_EXTERNAL,
+          static::TYPE_FOLDER,
+          static::TYPE_INTERNAL,
+          static::TYPE_PAGE,
+        ])
+        ->values();
+    });
+  }
 }

--- a/src/Netflex/Pages/Page.php
+++ b/src/Netflex/Pages/Page.php
@@ -23,8 +23,7 @@ class Page extends AbstractPage
           static::TYPE_FOLDER,
           static::TYPE_INTERNAL,
           static::TYPE_PAGE,
-        ])
-        ->values();
+        ]);
     });
   }
 }

--- a/src/Netflex/Pages/helpers.php
+++ b/src/Netflex/Pages/helpers.php
@@ -789,9 +789,7 @@ if (!function_exists('current_page')) {
       throw new TypeError('Argument 1 passed to ' . $frame['function'] . '() must be an instance of Netflex\Pages\AbstractPage, ' . $type . ' given on line ' . $frame['line']);
     }
 
-    App::bind('__current_page__', function () use ($value) {
-      return $value;
-    });
+    App::bind('__current_page__', fn() => $value);
 
     return $value;
   }


### PR DESCRIPTION
This PR improves bootstrapping times, as well as rendering times of components that utilize variables, static content or simililar, by improving the times and way they are deserialized.

## Variables
Variables are now deserialized once, then stored by alias, in order to not need to be iterated over when value is searched.

## Global Content
Due to global content being a shorter list, we employ similar tactics when deserializing (using once, and caching the class instances instead of just api response). But since this list is shorter, we're still iterating over the list.

## Template
Templates are also loaded into their own respective associative arrays and are now looked up via a map instead of a list.