### PR TITLE
Add eventing to API Client

### DIFF
--- a/src/Netflex/API/Events/RequestFailed.php
+++ b/src/Netflex/API/Events/RequestFailed.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Netflex\API\Events;
+
+
+use GuzzleHttp\Exception\RequestException;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class RequestFailed
+{
+  public RequestInterface $request;
+  public ?ResponseInterface $response = null;
+  public \Throwable $exception;
+
+  public function __construct(RequestInterface $request, \Throwable $exception)
+  {
+    $this->request = $request;
+    if ($exception instanceof RequestException) {
+      $this->response = $exception->getResponse();
+    }
+    $this->exception = $exception;
+  }
+}

--- a/src/Netflex/API/Events/RequestFailed.php
+++ b/src/Netflex/API/Events/RequestFailed.php
@@ -4,11 +4,16 @@ namespace Netflex\API\Events;
 
 
 use GuzzleHttp\Exception\RequestException;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 class RequestFailed
 {
+  use Dispatchable, InteractsWithSockets, SerializesModels;
+
   public RequestInterface $request;
   public ?ResponseInterface $response = null;
   public \Throwable $exception;

--- a/src/Netflex/API/Events/RequestStarted.php
+++ b/src/Netflex/API/Events/RequestStarted.php
@@ -2,10 +2,15 @@
 
 namespace Netflex\API\Events;
 
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
 use Psr\Http\Message\RequestInterface;
 
 class RequestStarted
 {
+  use Dispatchable, InteractsWithSockets, SerializesModels;
+
   public RequestInterface $request;
 
   public function __construct(RequestInterface $request) {

--- a/src/Netflex/API/Events/RequestStarted.php
+++ b/src/Netflex/API/Events/RequestStarted.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Netflex\API\Events;
+
+use Psr\Http\Message\RequestInterface;
+
+class RequestStarted
+{
+  public RequestInterface $request;
+
+  public function __construct(RequestInterface $request) {
+    $this->request = $request;
+  }
+}

--- a/src/Netflex/API/Events/RequestSucceeded.php
+++ b/src/Netflex/API/Events/RequestSucceeded.php
@@ -3,11 +3,16 @@
 namespace Netflex\API\Events;
 
 use GuzzleHttp\Promise\FulfilledPromise;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 class RequestSucceeded
 {
+  use Dispatchable, InteractsWithSockets, SerializesModels;
+
   public RequestInterface $request;
   public ?ResponseInterface $response = null;
 

--- a/src/Netflex/API/Events/RequestSucceeded.php
+++ b/src/Netflex/API/Events/RequestSucceeded.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Netflex\API\Events;
+
+use GuzzleHttp\Promise\FulfilledPromise;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class RequestSucceeded
+{
+  public RequestInterface $request;
+  public ?ResponseInterface $response = null;
+
+  public function __construct(RequestInterface $request, $response)
+  {
+    $this->request = $request;
+
+    if ($response instanceof ResponseInterface)
+      $this->response = $response;
+
+    else if ($response instanceof FulfilledPromise)
+      $this->response = $response->wait();
+  }
+
+}

--- a/src/Netflex/Signups/Signup.php
+++ b/src/Netflex/Signups/Signup.php
@@ -2,184 +2,182 @@
 
 namespace Netflex\Signups;
 
-use Exception;
-use Throwable;
-use JsonSerializable;
-
 use Brick\PhoneNumber\PhoneNumber;
-
+use Exception;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Support\Jsonable;
-use Illuminate\Support\Collection;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
-
-use Netflex\Query\Facades\Search;
+use JsonSerializable;
 use Netflex\API\Facades\API;
-use Netflex\Commerce\Order;
 use Netflex\Commerce\Contracts\Order as OrderContract;
+use Netflex\Commerce\Order;
+use Netflex\Customers\Customer;
+use Netflex\Query\Facades\Search;
 use Netflex\Structure\Entry;
 use Netflex\Structure\Model;
-use Netflex\Customers\Customer;
+use Throwable;
 
 class Signup implements JsonSerializable, Jsonable
 {
-    use Notifiable;
+  use Notifiable;
 
-    protected object $signup;
-    protected $model = Entry::class;
-    protected $customerModel = Customer::class;
+  protected object $signup;
+  protected $model = Entry::class;
+  protected $customerModel = Customer::class;
 
-    public function __construct($signup)
-    {
-        $this->signup = $signup;
+  public function __construct($signup)
+  {
+    $this->signup = $signup;
+  }
+
+  public function phone_countrycode()
+  {
+    if (!Str::startsWith($this->signup->phone, '+')) {
+      return '47';
     }
 
-    public function phone_countrycode()
-    {
-        if (!Str::startsWith($this->signup->phone, '+')) {
-            return '47';
-        }
-
-        try {
-            $parsed = PhoneNumber::parse($this->signup->phone, 'NO');
-            return $parsed->getCountryCode();
-        } catch (Exception $e) {
-            return null;
-        }
-
-        return null;
+    try {
+      $parsed = PhoneNumber::parse($this->signup->phone, 'NO');
+      return $parsed->getCountryCode();
+    } catch (Exception $e) {
+      return null;
     }
 
-    public function entry()
-    {
-        return ($this->model)::forceFind($this->signup->entry_id);
+    return null;
+  }
+
+  public function entry()
+  {
+    return ($this->model)::forceFind($this->signup->entry_id);
+  }
+
+  public function customer(): ?Authenticatable
+  {
+    return ($this->customerModel)::find($this->signup->customer_id);
+  }
+
+  public function order(): ?OrderContract
+  {
+    return Order::retrieve($this->order_id);
+  }
+
+  public function name(): ?string
+  {
+    return trim($this->signup->firstname . ' ' . $this->signup->surname);
+  }
+
+  public function __get($key)
+  {
+    try {
+      if (method_exists($this, $key)) {
+        return $this->{$key}();
+      }
+
+      if (property_exists($this->signup, $key)) {
+        return $this->signup->{$key};
+      }
+
+      if (property_exists($this->signup->data, $key)) {
+        return $this->signup->data->{$key};
+      }
+    } catch (Throwable $e) {
+      return null;
+    }
+  }
+
+  public static function find($id)
+  {
+    if ($signup = API::get('relations/signups/' . $id)) {
+      return new static($signup);
+    }
+  }
+
+  public static function resolve($code)
+  {
+    return new static(API::get('relations/signups/code/' . $code));
+  }
+
+  public static function all(Model $model): Collection
+  {
+    return collect(API::get('relations/signups'))
+      ->mapInto(static::class);
+  }
+
+  public static function forEntry(Model $model): Collection
+  {
+    return collect(API::get('relations/signups/entry/' . $model->id))
+      ->map(function ($signup) use ($model) {
+        $signup = new static($signup);
+        $signup->model = get_class($model);
+        return $signup;
+      });
+  }
+
+  public static function forOrder(OrderContract $order): Collection
+  {
+    return collect(API::get('relations/signups/order/' . $order->getOrderId()))
+      ->mapInto(static::class);
+  }
+
+  public static function countForEntry(Model $model): int
+  {
+    return API::get('relations/signups/count/' . $model->id) ?? 0;
+  }
+
+  public static function user(Authenticatable $user)
+  {
+    return collect(API::get('relations/signups/customer/' . $user->getAuthIdentifier()))->map(function ($signup) {
+      return new static($signup);
+    })->filter(function (Signup $signup) {
+      return $signup->entry() !== null;
+    })->values();
+  }
+
+  public static function query(string $query)
+  {
+    $results = Search::relation('signup')
+      ->ignorePublishingStatus()
+      ->limit(1000)
+      ->raw($query)
+      ->fetch();
+
+    if (count($results['data'])) {
+      return collect($results['data'])
+        ->map(function ($signup) {
+          return new static((object)$signup);
+        });
     }
 
-    public function customer(): ?Authenticatable
-    {
-        return ($this->customerModel)::find($this->signup->customer_id);
-    }
+    return null;
+  }
 
-    public function order(): ?OrderContract
-    {
-        return Order::retrieve($this->order_id);
-    }
+  public function jsonSerialize()
+  {
+    return $this->signup;
+  }
 
-    public function name(): ?string
-    {
-        return trim($this->signup->firstname . ' ' . $this->signup->surname);
-    }
+  public function toJSON($options = 0)
+  {
+    return json_encode($this->jsonSerialize(), $options);
+  }
 
-    public function __get($key)
-    {
-        try {
-            if (method_exists($this, $key)) {
-                return $this->{$key}();
-            }
+  public static function create(array $payload = [])
+  {
+    $shouldWaitForIndexing = config('netflex.signups.wait-for-index', false);
+    $response = API::post('relations/signups?_wait=' . ($shouldWaitForIndexing ? "1" : "0"), $payload);
+    return static::find($response->signup_id);
+  }
 
-            if (property_exists($this->signup, $key)) {
-                return $this->signup->{$key};
-            }
+  public static function createForEntry(Model $model, array $payload = [])
+  {
+    $payload['entry_id'] = $model->id;
+    return static::create($payload);
+  }
 
-            if (property_exists($this->signup->data, $key)) {
-                return $this->signup->data->{$key};
-            }
-        } catch (Throwable $e) {
-            return null;
-        }
-    }
-
-    public static function find($id)
-    {
-        if ($signup = API::get('relations/signups/' . $id)) {
-            return new static($signup);
-        }
-    }
-
-    public static function resolve($code)
-    {
-        return new static(API::get('relations/signups/code/' . $code));
-    }
-
-    public static function all(Model $model): Collection
-    {
-        return collect(API::get('relations/signups'))
-            ->mapInto(static::class);
-    }
-
-    public static function forEntry(Model $model): Collection
-    {
-        return collect(API::get('relations/signups/entry/' . $model->id))
-            ->map(function ($signup) use ($model) {
-                $signup = new static($signup);
-                $signup->model = get_class($model);
-                return $signup;
-            });
-    }
-
-    public static function forOrder(OrderContract $order): Collection
-    {
-        return collect(API::get('relations/signups/order/' . $order->getOrderId()))
-            ->mapInto(static::class);
-    }
-
-    public static function countForEntry(Model $model): int
-    {
-        return API::get('relations/signups/count/' . $model->id) ?? 0;
-    }
-
-    public static function user(Authenticatable $user)
-    {
-        return collect(API::get('relations/signups/customer/' . $user->getAuthIdentifier()))->map(function ($signup) {
-            return new static($signup);
-        })->filter(function (Signup $signup) {
-            return $signup->entry() !== null;
-        })->values();
-    }
-
-    public static function query(string $query)
-    {
-        $results = Search::relation('signup')
-            ->ignorePublishingStatus()
-            ->limit(1000)
-            ->raw($query)
-            ->fetch();
-
-        if (count($results['data'])) {
-            return collect($results['data'])
-                ->map(function ($signup) {
-                    return new static((object) $signup);
-                });
-        }
-
-        return null;
-    }
-
-    public function jsonSerialize()
-    {
-        return $this->signup;
-    }
-
-    public function toJSON($options = 0)
-    {
-        return json_encode($this->jsonSerialize(), $options);
-    }
-
-    public static function create(array $payload = [])
-    {
-        $response = API::post('relations/signups', $payload);
-        return static::find($response->signup_id);
-    }
-
-    public static function createForEntry(Model $model, array $payload = [])
-    {
-        $payload['entry_id'] = $model->id;
-        return static::create($payload);
-    }
-
-    public function delete()
-    {
-        return API::delete('relations/signups/' . $this->signup->id);
-    }
+  public function delete()
+  {
+    return API::delete('relations/signups/' . $this->signup->id);
+  }
 }


### PR DESCRIPTION
This PR adds a few new events for the API client when it performs requests. It adds three events

`RequestStarted`, `RequestSucceeded` and `RequestFailed`. 

Content-API has also gotten a `?_wait` flag for its signup POST and PUT endpoints, which like entries, makes you wait for indexing to be completed before continuing. This PR also adds a small config variable one can set when creating signups that makes you wait for indexing