### PR TITLE
Refactor CacheStore

### DIFF
--- a/src/Netflex/Pages/Providers/RouteServiceProvider.php
+++ b/src/Netflex/Pages/Providers/RouteServiceProvider.php
@@ -351,6 +351,10 @@ class RouteServiceProvider extends ServiceProvider
 
       $missingKeys = [];
       foreach ($keys as $key) {
+        if ($request->header('X-KEY-ENCODING', 'none') === 'base64') {
+          $key = base64_decode($key);
+        }
+
         $key = trim($key);
 
         if ($key === 'pages') {


### PR DESCRIPTION
This commit refactors the CacheStore endpoint in order to support multiple cache keys being cleared.

**This commit*:*
* Refactors the CacheCleared event in such a way that it gets emitted regardless of key presence, as the `KeyForgotten` event that is standard in Laravel works exactly the same as the old `CacheCleared` event.

* Removes an unnecessary check of $request->key that would always succeed at the time it was checked.

* Removes return statements from key loop so that the loop processes each key, and not just the first one.
