### PR TITLE
fix breaking change in extensions constructor

### DIFF
--- a/src/Netflex/Pages/Extension.php
+++ b/src/Netflex/Pages/Extension.php
@@ -20,7 +20,7 @@ abstract class Extension implements Renderable, Responsable
   protected $name;
   protected $data = [];
 
-  public function __construct(array $data)
+  public function __construct(array $data = [])
   {
     if (isset($data['view']) && !Str::startsWith($data['view'], 'extensions.')) {
       $data['view'] = 'extensions.' . $data['view'];


### PR DESCRIPTION
Previously there were no constructor for this class. Introducing a constructor and setting mandatory arguments breaks existing usage of the class. This adds a default value to the argument so as to no longer cause errors.