### PR TITLE
Swaps out CssToInlineStyles dependency from unmaintained fork to original package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "spatie/once": "^2.2",
         "brick/phonenumber": "^0.4.0",
         "html2text/html2text": "^4.3",
-        "voku/css-to-inline-styles": "^2.0"
+        "tijsverkoyen/css-to-inline-styles": "^2.2"
     },
     "require-dev": {
         "illuminate/cache": "^8.0|^9.0|^10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d5db416e4e737a61e5bd397f17e7fa1f",
+    "content-hash": "009ab79b6d2eb96a14ba760e74a8273f",
     "packages": [
         {
             "name": "apility/laravel-ngrok",
@@ -6408,23 +6408,23 @@
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
-            "version": "2.2.6",
+            "version": "v2.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tijsverkoyen/CssToInlineStyles.git",
-                "reference": "c42125b83a4fa63b187fdf29f9c93cb7733da30c"
+                "reference": "83ee6f38df0a63106a9e4536e3060458b74ccedb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/c42125b83a4fa63b187fdf29f9c93cb7733da30c",
-                "reference": "c42125b83a4fa63b187fdf29f9c93cb7733da30c",
+                "url": "https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/83ee6f38df0a63106a9e4536e3060458b74ccedb",
+                "reference": "83ee6f38df0a63106a9e4536e3060458b74ccedb",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "php": "^5.5 || ^7.0 || ^8.0",
-                "symfony/css-selector": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.0"
+                "symfony/css-selector": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0 || ^7.5 || ^8.5.21 || ^9.5.10"
@@ -6455,9 +6455,9 @@
             "homepage": "https://github.com/tijsverkoyen/CssToInlineStyles",
             "support": {
                 "issues": "https://github.com/tijsverkoyen/CssToInlineStyles/issues",
-                "source": "https://github.com/tijsverkoyen/CssToInlineStyles/tree/2.2.6"
+                "source": "https://github.com/tijsverkoyen/CssToInlineStyles/tree/v2.2.7"
             },
-            "time": "2023-01-03T09:29:04+00:00"
+            "time": "2023-12-08T13:03:43+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -6544,74 +6544,6 @@
             "time": "2022-10-16T01:01:54+00:00"
         },
         {
-            "name": "voku/css-to-inline-styles",
-            "version": "2.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/voku/CssToInlineStyles.git",
-                "reference": "64e16278545d5ce1b6197136b3fbbaf90f1f2670"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/voku/CssToInlineStyles/zipball/64e16278545d5ce1b6197136b3fbbaf90f1f2670",
-                "reference": "64e16278545d5ce1b6197136b3fbbaf90f1f2670",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "php": ">=7.0.0",
-                "symfony/css-selector": "~3.0 || ~4.0 || ~5.0",
-                "voku/simple_html_dom": "~4.7"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~6.0 || ~7.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.6.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "voku\\CssToInlineStyles\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Tijs Verkoyen",
-                    "email": "css_to_inline_styles@verkoyen.eu",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Lars Moelleken",
-                    "email": "lars@moelleken.org",
-                    "homepage": "https://github.com/voku",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Only a Fork of -> CssToInlineStyles is a class that enables you to convert HTML-pages/files into HTML-pages/files with inline styles. This is very useful when you're sending emails.",
-            "homepage": "https://github.com/voku/CssToInlineStyles",
-            "keywords": [
-                "CSSToHtml",
-                "CSSinline",
-                "css",
-                "css-to-html",
-                "email",
-                "inline",
-                "style"
-            ],
-            "support": {
-                "issues": "https://github.com/voku/CssToInlineStyles/issues",
-                "source": "https://github.com/voku/CssToInlineStyles/tree/master"
-            },
-            "time": "2020-02-23T12:51:47+00:00"
-        },
-        {
             "name": "voku/portable-ascii",
             "version": "1.6.1",
             "source": {
@@ -6684,87 +6616,6 @@
                 }
             ],
             "time": "2022-01-24T18:55:24+00:00"
-        },
-        {
-            "name": "voku/simple_html_dom",
-            "version": "4.8.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/voku/simple_html_dom.git",
-                "reference": "9ef90f0280fe16054c117e04ea86617ce0fcdd35"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/voku/simple_html_dom/zipball/9ef90f0280fe16054c117e04ea86617ce0fcdd35",
-                "reference": "9ef90f0280fe16054c117e04ea86617ce0fcdd35",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-libxml": "*",
-                "ext-simplexml": "*",
-                "php": ">=7.0.0",
-                "symfony/css-selector": "~3.0 || ~4.0 || ~5.0 || ~6.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~6.0 || ~7.0 || ~9.0"
-            },
-            "suggest": {
-                "voku/portable-utf8": "If you need e.g. UTF-8 fixed output."
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "voku\\helper\\": "src/voku/helper/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "dimabdc",
-                    "email": "support@titor.ru",
-                    "homepage": "https://github.com/dimabdc",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Lars Moelleken",
-                    "homepage": "https://www.moelleken.org/",
-                    "role": "Fork-Maintainer"
-                }
-            ],
-            "description": "Simple HTML DOM package.",
-            "homepage": "https://github.com/voku/simple_html_dom",
-            "keywords": [
-                "HTML Parser",
-                "dom",
-                "php dom"
-            ],
-            "support": {
-                "issues": "https://github.com/voku/simple_html_dom/issues",
-                "source": "https://github.com/voku/simple_html_dom/tree/4.8.8"
-            },
-            "funding": [
-                {
-                    "url": "https://www.paypal.me/moelleken",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/voku",
-                    "type": "github"
-                },
-                {
-                    "url": "https://www.patreon.com/voku",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/voku/simple_html_dom",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-02-12T16:15:15+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -9535,5 +9386,5 @@
         "php": "^7.4|^8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/Netflex/Newsletters/Newsletter.php
+++ b/src/Netflex/Newsletters/Newsletter.php
@@ -15,7 +15,7 @@ use Netflex\Newsletters\Traits\HidesDefaultFields;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\HtmlString;
-use voku\CssToInlineStyles\CssToInlineStyles;
+use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
 
 /**
  * @property int $id
@@ -295,7 +295,7 @@ class Newsletter extends QueryableModel
   public function renderPreview($type = 'html')
   {
     $content = $this->render()->toHtml();
-    $output = (new CssToInlineStyles($content))->convert();
+    $output = (new CssToInlineStyles())->convert($content);
     $outputText = (new Html2Text($content))->getText();
     switch($type) {
       case 'text':
@@ -313,7 +313,7 @@ class Newsletter extends QueryableModel
   public function renderAndSave()
   {
       $content = $this->render()->toHtml();
-      $this->output = mb_convert_entities((new CssToInlineStyles($content))->convert());
+      $this->output = mb_convert_entities((new CssToInlineStyles())->convert($content));
       $this->outputText = mb_convert_entities((new Html2Text($content))->getText());
       $this->save();
   }


### PR DESCRIPTION
This PR first and foremost fixes the fact that CSS inlining in newsletters was not set up correctly and thus weren't happening.

It also swaps out the Composer package responsible for doing the inlining, from an unmaintained fork ([voku/CssToInlineStyles](https://github.com/voku/CssToInlineStyles)) last updated 4 years ago to the original package ([tijsverkoyen/CssToInlineStyles](https://github.com/tijsverkoyen/CssToInlineStyles)) last updated three months ago.