### PR TITLE
Add Automation Tags

### DIFF
--- a/src/Netflex/Pages/Providers/PagesServiceProvider.php
+++ b/src/Netflex/Pages/Providers/PagesServiceProvider.php
@@ -2,21 +2,19 @@
 
 namespace Netflex\Pages\Providers;
 
-use Netflex\Pages\Components\EditorButton;
-use Netflex\Pages\Components\Image;
-use Netflex\Pages\Components\Picture;
-use Netflex\Pages\Components\Blocks;
-use Netflex\Pages\Components\Inline;
-use Netflex\Pages\Components\EditorTools;
-use Netflex\Pages\Components\Seo;
-use Netflex\Pages\Components\StaticContent;
-use Netflex\Pages\Components\BackgroundImage;
-use Netflex\Pages\Components\Nav;
-
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Config;
-
 use Illuminate\Support\ServiceProvider;
+use Netflex\Pages\Components\BackgroundImage;
+use Netflex\Pages\Components\Blocks;
+use Netflex\Pages\Components\EditorButton;
+use Netflex\Pages\Components\EditorTools;
+use Netflex\Pages\Components\Image;
+use Netflex\Pages\Components\Inline;
+use Netflex\Pages\Components\Nav;
+use Netflex\Pages\Components\Picture;
+use Netflex\Pages\Components\Seo;
+use Netflex\Pages\Components\StaticContent;
 use Netflex\Pages\Controllers\Controller;
 
 class PagesServiceProvider extends ServiceProvider
@@ -49,6 +47,14 @@ class PagesServiceProvider extends ServiceProvider
       __DIR__ . '/../config/pages.php',
       'pages'
     );
+
+    $this->mergeConfigFrom(
+      __DIR__ . '/../config/automation_emails/tags.php',
+      'automation_emails.tags'
+    );
+    $this->publishes([
+      __DIR__ . '/../config/automation_emails/tags.php' => $this->app->configPath('automation_emails/tags.php')
+    ], 'automation-mail-configs');
 
     $this->loadViewsFrom(__DIR__ . '/../resources/views', 'netflex-pages');
 

--- a/src/Netflex/Pages/Providers/PagesServiceProvider.php
+++ b/src/Netflex/Pages/Providers/PagesServiceProvider.php
@@ -78,6 +78,8 @@ class PagesServiceProvider extends ServiceProvider
       StaticContent::class,
     ]);
 
+    $this->loadViewsFrom(__DIR__ . '/../resources/views', 'pages');
+
     if ($prefix) {
       $this->loadViewComponentsAs($prefix, $components);
     } else {

--- a/src/Netflex/Pages/Providers/RouteServiceProvider.php
+++ b/src/Netflex/Pages/Providers/RouteServiceProvider.php
@@ -2,39 +2,38 @@
 
 namespace Netflex\Pages\Providers;
 
-use Throwable;
-use ReflectionClass;
-
-use Netflex\API\Facades\API;
 use Carbon\Carbon;
 use Exception;
-use Netflex\Pages\Page;
-use Netflex\Pages\Middleware\BindPage;
-use Netflex\Pages\Middleware\GroupAuthentication;
-use Netflex\Pages\Controllers\PageController;
-use Netflex\Pages\Controllers\Controller;
-use Netflex\Pages\Middleware\JwtProxy;
-use Netflex\Foundation\Redirect;
-use Netflex\Pages\JwtPayload;
-use Netflex\Pages\PreviewRequest;
-use Netflex\Pages\Controllers\ControllerNotImplementedController;
-
-use Illuminate\Support\Facades\URL;
-use Illuminate\Support\Facades\Route;
-use Illuminate\Http\Request;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
 use Laravelium\Sitemap\Sitemap;
+use Netflex\API\Facades\API;
+use Netflex\Foundation\Redirect;
 use Netflex\Newsletters\Newsletter;
+use Netflex\Notifications\Automation\AutomationEmail;
 use Netflex\Pages\AbstractPage;
 use Netflex\Pages\Contracts\CompilesException;
+use Netflex\Pages\Controllers\Controller;
+use Netflex\Pages\Controllers\ControllerNotImplementedController;
+use Netflex\Pages\Controllers\PageController;
 use Netflex\Pages\Events\CacheCleared;
 use Netflex\Pages\Exceptions\InvalidControllerException;
 use Netflex\Pages\Exceptions\InvalidRouteDefintionException;
+use Netflex\Pages\JwtPayload;
+use Netflex\Pages\Middleware\BindPage;
+use Netflex\Pages\Middleware\GroupAuthentication;
+use Netflex\Pages\Middleware\JwtProxy;
+use Netflex\Pages\Page;
+use Netflex\Pages\PreviewRequest;
+use ReflectionClass;
+use Throwable;
 
 class RouteServiceProvider extends ServiceProvider
 {
@@ -205,7 +204,7 @@ class RouteServiceProvider extends ServiceProvider
       $page->toResponse($request);
     }
 
-    /** @var PageController $controller  */
+    /** @var PageController $controller */
     $controller = App::make($class);
     $previousPage = current_page();
     current_page($page);
@@ -272,10 +271,18 @@ class RouteServiceProvider extends ServiceProvider
   protected function handleNewsletter(Request $request, JwtPayload $payload)
   {
     if ($newsletter = Newsletter::where('id', $payload->newsletter_id)->first()) {
+
+      $automationMail = null;
+      $newsletter->automation != "1" || $automationMail = AutomationEmail::find($newsletter->id);
+
       if ($page = $newsletter->page) {
 
         $page = $page->loadRevision($page->revision);
         current_newsletter($newsletter);
+
+        if ($automationMail) {
+          $this->extendEditorToolsToIncludeTags($automationMail);
+        }
 
         if ($payload->mode === 'preview') {
           return $newsletter->renderPreview($payload->preview_type ?? 'html');
@@ -538,7 +545,7 @@ class RouteServiceProvider extends ServiceProvider
       ]);
 
       $routeCache = $routeSource;
-      Cache::rememberForever(static::ROUTE_CACHE, fn () => $routeCache);
+      Cache::rememberForever(static::ROUTE_CACHE, fn() => $routeCache);
     }
 
     Route::middleware('netflex')
@@ -606,5 +613,35 @@ class RouteServiceProvider extends ServiceProvider
   protected function getSitemapEntries()
   {
     return [];
+  }
+
+  /**
+   * @param $automationMail
+   * @return void
+   */
+  public function extendEditorToolsToIncludeTags($automationMail): void
+  {
+    $this->app->extend('__editor_tools__', function ($string) use ($automationMail) {
+      return $this->insertBefore($string, '<div id="netflex-advanced-content-widget-header">', [
+        (string)view('pages::newsletter-tags', [
+          'tags' => config("automation_mails.tags.$automationMail->id", []),
+        ]),
+        '<!-- PRE: Header -->'
+      ]);
+    });
+  }
+
+  private function insertBefore(string $whole, string $before, $to_insert): string
+  {
+    $to_insert = is_array($to_insert) ? implode("", $to_insert) : (string)$to_insert;
+    $parts = explode($before, $whole);
+
+    return ($parts[0] ?? '') . $to_insert . $before . ($parts[1] ?? '');
+  }
+
+  private function insertAfter(string $whole, string $after, string $to_insert): string
+  {
+    $parts = explode($after, $whole);
+    return ($parts[0] ?? '') . $after . $to_insert . ($parts[1] ?? '');
   }
 }

--- a/src/Netflex/Pages/Providers/RouteServiceProvider.php
+++ b/src/Netflex/Pages/Providers/RouteServiceProvider.php
@@ -622,11 +622,20 @@ class RouteServiceProvider extends ServiceProvider
   public function extendEditorToolsToIncludeTags($automationMail): void
   {
     $this->app->extend('__editor_tools__', function ($string) use ($automationMail) {
+
+      $tags = config("automation_emails.tags.$automationMail->id.attributes", []);
+
+      if (config("automation_emails.tags.$automationMail->id.include_globals", false)) {
+        $tags = [
+          ...config("automation_emails.tags.global.attributes", []),
+          ...$tags,
+        ];
+      }
+
       return $this->insertBefore($string, '<div id="netflex-advanced-content-widget-header">', [
-        (string)view('pages::newsletter-tags', [
-          'tags' => config("automation_mails.tags.$automationMail->id", []),
-        ]),
-        '<!-- PRE: Header -->'
+        '<!-- PRE: Addons -->',
+        (string)view('pages::newsletter-tags', compact('tags')),
+        '<!-- POST: Addons -->'
       ]);
     });
   }

--- a/src/Netflex/Pages/config/automation_emails/tags.php
+++ b/src/Netflex/Pages/config/automation_emails/tags.php
@@ -1,0 +1,71 @@
+<?php
+
+return [
+  /**
+   *
+   * /// ---------------------------------------------------------------------------------------------------------
+   * /// Reusable sections
+   * ///
+   * /// These sections can be included and will be merged into a mail
+   * /// ---------------------------------------------------------------------------------------------------------
+   *
+   */
+  'includes' => [
+    'customer' => [
+      '' => [
+        '_group_header' => 'Kundeinformasjon',
+        'firstname' => 'Fornavn',
+        'surname' => 'Etternavn',
+        'mail' => 'E-post addresse'
+      ],
+    ],
+    'order' => [
+      'order' => [
+        '_group_header' => "Ordre",
+        'secret' => 'Ordrens hemmelige kode, ofte brukt i URLer som kvitteringsurler',
+        'checkout' => [
+          'firstname' => 'Kundens fornavn',
+          'surname' => 'Kundens etternavn'
+        ]
+      ],
+    ],
+    'article' => [
+      'article' => [
+        '_group_header' => 'Artikkelinformasjon',
+        'name' => 'Navn på artikkel',
+        'author' => 'Hvem som har laget artikkelen',
+        'starts_at' => 'Når arrangementet tilknyttet artikkelen begynner',
+      ],
+    ],
+  ],
+
+
+  /**
+   *
+   * /// ---------------------------------------------------------------------------------------------------------
+   * /// Automation Emails
+   * ///
+   * /// Type the ID of the automation-email and
+   * /// ---------------------------------------------------------------------------------------------------------
+   *
+   */
+  'mails' => [
+    /// Example entry, the id is set to -1 to avoid unintended side effects, this id should be a positive integer
+    /// corresponding to an automation mail in netflex.
+    -1 => [
+      /// Insert names of the includes you want to include
+      'include' => ['customer', 'order', 'article'],
+
+      /// Here you can add automation-mail specific fields that can not be shared between automation-mails.
+      'attributes' => [
+        'membership' => [
+          '_group_header' => 'Medlemskap',
+          'has_paid' => 'Om brukeren har betalt', /// This resolves to 'data.membership.has_paid'
+          'paid_at' => 'Brukeren betalte den'   /// This resolves to 'data.membership.paid_at
+        ],
+        'kake.is_it_a_lie' => 'Is a lie', /// This resolves to 'data.kake',
+        'kake.is_lie' => 'Yes if cake is lie'/// This resolves to 'data.kake.is_lie'
+      ],
+    ]
+  ]
+];

--- a/src/Netflex/Pages/resources/views/newsletter-tag.blade.php
+++ b/src/Netflex/Pages/resources/views/newsletter-tag.blade.php
@@ -2,7 +2,7 @@
 
 @if(is_array($tag))
   @foreach($tag as $key => $nextTag)
-    @include('pages::newsletter-tag', ['key' => $key, 'tag' => $nextTag, 'prefix' => [...($prefix ?? []), $key]])
+    @include('pages::newsletter-tag', ['key' => $key, 'tag' => $nextTag, 'prefix' => array_filter([...($prefix ?? []), $key])])
   @endforeach
 @else
 

--- a/src/Netflex/Pages/resources/views/newsletter-tag.blade.php
+++ b/src/Netflex/Pages/resources/views/newsletter-tag.blade.php
@@ -1,0 +1,24 @@
+<!-- newsletter-tag -->
+
+@if(is_array($tag))
+  @foreach($tag as $key => $nextTag)
+    @include('pages::newsletter-tag', ['key' => $key, 'tag' => $nextTag, 'prefix' => [...($prefix ?? []), $key]])
+  @endforeach
+@else
+
+  @if(($key ?? '') == '_group_header')
+    <div class="nf-automation-mail-tag-header">
+      <h3>{{ $tag }}</h3>
+    </div>
+  @else
+    <button class="nf-automation-mail-tag-option" data-option="{{ implode(".", $prefix ?? []) }}">
+      <strong>
+        <small style="">{{ implode(".", $prefix ?? []) }}</small>
+      </strong>
+      <div style="color: #aaaaaa; font-size: 0.75rem;">
+        {{ $tag }}
+      </div>
+    </button>
+  @endif
+@endif
+<!-- /newsletter-tag -->

--- a/src/Netflex/Pages/resources/views/newsletter-tags.blade.php
+++ b/src/Netflex/Pages/resources/views/newsletter-tags.blade.php
@@ -5,8 +5,13 @@
 <div class="tag-list closed" style="overflow: scroll; display: flex; flex-direction: column; border-bottom: 1px #cdcdcd solid; ">
   <div style="padding: 10px 20px; font-size: 0.75rem;">
     @verbatim
-    For å legge inn data fra eksternt innhold kan du i tekster og lenker legge inn tags.
-    Her er en utdypende beskrivelse for tags <span style="padding: 4px 2px; background: #cdcdcd; border-radius: 6px; box-shadow: 1 1 2px rgba(0,0,0,0.2); font-family: mono; display: inline-block;">{{ data.order.secret }}</span>
+    <p>Det er mulig å bruke variabler i epostene. Disse variablene vil erstattes med korrekte verdier for kunden som skal motta mailen.</p>
+    <p>Noen av disse automasjonsmailene har tilgang på mer informasjon en bare kunde info, basert på bruksområdet. Dette kan være ting som ordre, billetter eller liknende.</p>
+    <p>
+      For å sette inn en variabel, trykk i et innholdsområde, slik at du kan redigere teksten der du ønsker å sette inn variabelen.
+      Trykk så på navnet på variabelen i listen under denne meldingen, eller skriv inn navnet på ønsket variabel med tegn rundt slik som dette
+      <div style="padding: 4px 2px; background: #cdcdcd; border-radius: 6px; box-shadow: 1 1 2px rgba(0,0,0,0.2); font-family: mono; display: inline-block;">{{ data.order.secret }}</div>
+    </p>
     @endverbatim
   </div>
   @include("pages::newsletter-tag", ['tag' => $tags, 'prefix' => ['data']])

--- a/src/Netflex/Pages/resources/views/newsletter-tags.blade.php
+++ b/src/Netflex/Pages/resources/views/newsletter-tags.blade.php
@@ -1,0 +1,74 @@
+@if(sizeof($tags))
+<div id="netflex-advanced-yay-widget-header" style="padding: 10px 20px; border-bottom: 1px #cdcdcd solid; padding-bottom: 1rem;">
+  <span style="margin-right:10px;"> + </span>Innholdstyper
+</div>
+<div class="tag-list closed" style="overflow: scroll; display: flex; flex-direction: column; border-bottom: 1px #cdcdcd solid; ">
+  <div style="padding: 10px 20px; font-size: 0.75rem;">
+    @verbatim
+    For å legge inn data fra eksternt innhold kan du i tekster og lenker legge inn tags.
+    Her er en utdypende beskrivelse for tags <span style="padding: 4px 2px; background: #cdcdcd; border-radius: 6px; box-shadow: 1 1 2px rgba(0,0,0,0.2); font-family: mono; display: inline-block;">{{ data.order.secret }}</span>
+    @endverbatim
+  </div>
+  @include("pages::newsletter-tag", ['tag' => $tags, 'prefix' => ['data']])
+</div>
+<style>
+  .tag-list {
+    max-height:  50vh;
+    padding: 1rem 0rem;
+
+    transition: 100ms 100ms ease-in;
+  }
+
+  .tag-list.closed {
+    max-height: 0vh;
+    padding: 0;
+  }
+
+  .nf-automation-mail-tag-header,
+  .nf-automation-mail-tag-option {
+    padding: 0.5rem 2rem;
+    background: transparent;
+    border: 0;
+
+    text-align: left;
+  }
+
+  .nf-automation-mail-tag-option {
+    width: 100%;
+  }
+  .nf-automation-mail-tag-option > * {
+    pointer-events: none;
+  }
+
+  .nf-automation-mail-tag-option:hover {
+    cursor: pointer;
+    background: #fefefe;
+  }
+</style>
+<script>
+  document.querySelector("#netflex-advanced-yay-widget-header").addEventListener('click', function(event) {
+    event.target.parentElement.querySelector('.tag-list').classList.toggle('closed')
+  })
+
+  let currentEditor;
+
+  CKEDITOR.on( 'instanceReady', function( event ) {
+    event.editor.on( 'focus', function() {
+      console.log( 'focused', this );
+
+      currentEditor = this
+    });
+  });
+
+  document.querySelectorAll('.nf-automation-mail-tag-option').forEach(element => {
+    element.addEventListener('click', function(event) {
+      event.preventDefault()
+      console.log(event.target)
+      console.log(currentEditor?.getSelection().getRanges()[0])
+      @verbatim
+      currentEditor?.insertText(`{{ ${event.target.getAttribute('data-option')} }}`)
+      @endverbatim
+    })
+  })
+</script>
+@endif


### PR DESCRIPTION
This PR introduces a new way of listing automation mail replacement tags in the sidebar when editing emails.

The feature is meant to simplify editing automation mails, hopefully making it slightly more intuitive for users to edit replacement fields.

* It adds a new config file where you can set up which tags are visible for each automation email.
* Shows said replacement tags when editing emails.
* Adds a command to publish the config if you want to change it.

Example is here
![image](https://github.com/netflex-sdk/framework/assets/1438488/5cabe016-705d-42af-bee0-13e7ba3e22f9)

Created because of NFP-103
