### PR TITLE
Add more Netflexapp Actions relating to Signups

### DIFF
--- a/src/Netflex/Actions/Contracts/Signups/DeleteSignupsControllerContract.php
+++ b/src/Netflex/Actions/Contracts/Signups/DeleteSignupsControllerContract.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Netflex\Actions\Contracts\Signups;
+
+use Netflex\Actions\Requests\Signups\DeleteSignupsRequest;
+
+interface DeleteSignupsControllerContract
+{
+  public function deleteSignups(DeleteSignupsRequest $request): void;
+}

--- a/src/Netflex/Actions/Contracts/Signups/MoveSignupsControllerContract.php
+++ b/src/Netflex/Actions/Contracts/Signups/MoveSignupsControllerContract.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Netflex\Actions\Contracts\Signups;
+
+use Illuminate\Http\Request;
+use Netflex\Actions\Requests\Signups\MoveSignupRequest;
+
+interface MoveSignupsControllerContract
+{
+
+  /**
+   *
+   * Return an array with BookingFormFields
+   *
+   * @param Request $request
+   * @param string $id
+   * @return array[BookingFormField]
+   */
+  public function moveSignupForm(Request $request, string $id): array;
+
+  /**
+   * @param MoveSignupRequest $request
+   * @param string $id
+   * @return mixed
+   */
+  public function moveSignupAction(MoveSignupRequest $request, string $id);
+
+}

--- a/src/Netflex/Actions/Providers/NetflexappConnectionProvider.php
+++ b/src/Netflex/Actions/Providers/NetflexappConnectionProvider.php
@@ -131,10 +131,10 @@ abstract class NetflexappConnectionProvider extends RouteServiceProvider
       }
 
       if ($this->deleteSignupsController) {
-        Route::post('signups/delete', [$this->deleteSignupsController, ''])
+        Route::post('signups/delete', [$this->deleteSignupsController, 'deleteSignups'])
+          ->name('netflexapp.actions.signups.delete');
       }
     });
-
 
 
   }

--- a/src/Netflex/Actions/Providers/NetflexappConnectionProvider.php
+++ b/src/Netflex/Actions/Providers/NetflexappConnectionProvider.php
@@ -5,6 +5,7 @@ namespace Netflex\Actions\Providers;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider;
 use Illuminate\Support\Facades\Route;
 use Netflex\Actions\Contracts\Reservations\ActionControllerContract;
+use Netflex\Actions\Contracts\Signups\MoveSignupsControllerContract;
 use Netflex\Actions\Controllers\Orders\Refunds\FormController as OrdersRefundsFormController;
 use Netflex\Actions\Controllers\Reservations\FormController;
 use Netflex\Actions\Exceptions\InvalidActionClassException;
@@ -15,94 +16,114 @@ abstract class NetflexappConnectionProvider extends RouteServiceProvider
 {
 
 
-    abstract function registerProviders();
+  abstract function registerProviders();
 
-    private ?string $reservationsActionController = null;
-    private ?string $ordersRefundFormController = null;
-    private ?string $ordersRefundActionController = null;
+  private ?string $reservationsActionController = null;
+  private ?string $ordersRefundFormController = null;
+  private ?string $ordersRefundActionController = null;
+  private ?string $moveSignupsController = null;
+
+  public function register()
+  {
+    $this->registerProviders();
+    parent::register();
+  }
+
+  /**
+   * Registers which controller is to be used for the reservations functionality
+   *
+   * @param string $actionController Must be a class string to a class that implements the [ActionControllerContract] for the Reservations module
+   * @throws \ReflectionException
+   * @throws InvalidActionClassException
+   */
+  protected function setReservationsActionController(string $actionController)
+  {
+
+    if ((new \ReflectionClass($actionController))->implementsInterface(ActionControllerContract::class)) {
+      $this->reservationsActionController = $actionController;
+    } else {
+      $acc = ActionControllerContract::class;
+      throw new InvalidActionClassException($actionController, $acc);
+    }
+  }
+
+  protected function setMoveSignupsActionController(string $actionController)
+  {
+    if ((new \ReflectionClass($actionController))->implementsInterface(MoveSignupsControllerContract::class)) {
+      $this->moveSignupsController = $actionController;
+    } else {
+      $acc = ActionControllerContract::class;
+      throw new InvalidActionClassException($actionController, $acc);
+    }
+  }
 
 
-    public function register()
-    {
-        $this->registerProviders();
-        parent::register();
+  /**
+   *
+   * Registers a handler for the Orders/Refunds action
+   *
+   * You must supply a form controller that is used to resolve the correct order and cart item
+   * As well as an action controller that must implement the action controller interface
+   *
+   * @param string $formDescriber Must be a class that is a subclass of the [Netflex\Actions\Controllers\Orders\Refunds\FormController] class.
+   * @param string $actionController Must be a class that implements the [Netflex\Actions\Contracts\Orders\Refunds\ActionControllerContract::class]
+   * @throws InvalidFormDescriberException
+   * @throws \ReflectionException
+   * @throws InvalidActionClassException
+   */
+  protected function setOrdersRefundsActionControllers(string $formDescriber, string $actionController)
+  {
+    if (is_subclass_of($formDescriber, OrdersRefundsFormController::class) == false) {
+      $acc = OrdersRefundsFormController::class;
+      throw new InvalidFormDescriberException("Class [$formDescriber] should extend [$acc], but it does not");
     }
 
-    /**
-     * Registers which controller is to be used for the reservations functionality
-     *
-     * @param string $actionController Must be a class string to a class that implements the [ActionControllerContract] for the Reservations module
-     * @throws \ReflectionException
-     * @throws InvalidActionClassException
-     */
-    protected function setReservationsActionController(string $actionController)
-    {
-
-        if ((new \ReflectionClass($actionController))->implementsInterface(ActionControllerContract::class)) {
-            $this->reservationsActionController = $actionController;
-        } else {
-            $acc = ActionControllerContract::class;
-            throw new InvalidActionClassException($actionController, $acc);
-        }
+    if ((new \ReflectionClass($actionController))->implementsInterface(\Netflex\Actions\Contracts\Orders\Refunds\ActionControllerContract::class) == false) {
+      $acc = \Netflex\Actions\Contracts\Orders\Refunds\ActionControllerContract::class;
+      throw new InvalidActionClassException($actionController, $acc);
     }
 
+    $this->ordersRefundFormController = $formDescriber;
+    $this->ordersRefundActionController = $actionController;
+  }
 
-    /**
-     *
-     * Registers a handler for the Orders/Refunds action
-     *
-     * You must supply a form controller that is used to resolve the correct order and cart item
-     * As well as an action controller that must implement the action controller interface
-     *
-     * @param string $formDescriber Must be a class that is a subclass of the [Netflex\Actions\Controllers\Orders\Refunds\FormController] class.
-     * @param string $actionController Must be a class that implements the [Netflex\Actions\Contracts\Orders\Refunds\ActionControllerContract::class]
-     * @throws InvalidFormDescriberException
-     * @throws \ReflectionException
-     * @throws InvalidActionClassException
-     */
-    protected function setOrdersRefundsActionControllers(string $formDescriber, string $actionController)
-    {
-        if (is_subclass_of($formDescriber, OrdersRefundsFormController::class) == false) {
-            $acc = OrdersRefundsFormController::class;
-            throw new InvalidFormDescriberException("Class [$formDescriber] should extend [$acc], but it does not");
-        }
-
-        if ((new \ReflectionClass($actionController))->implementsInterface(\Netflex\Actions\Contracts\Orders\Refunds\ActionControllerContract::class) == false) {
-            $acc = \Netflex\Actions\Contracts\Orders\Refunds\ActionControllerContract::class;
-            throw new InvalidActionClassException($actionController, $acc);
-        }
-
-        $this->ordersRefundFormController = $formDescriber;
-        $this->ordersRefundActionController = $actionController;
+  public function map()
+  {
+    if ($this->reservationsActionController) {
+      $actionController = $this->reservationsActionController;
+      Route::middleware('api')->prefix(".well-known/netflex/actions/")->group(function () use ($actionController) {
+        Route::middleware(WebhookAuthMiddleware::class)->group(function () use ($actionController) {
+          Route::any('reservations/form', [FormController::class, 'createForm'])->name('netflexapp.actions.reservations.form');
+          Route::post("reservations/create", [$actionController, 'create'])->name("netflexapp.actions.reservations.create");
+          Route::post("reservations/update", [$actionController, 'update'])->name("netflexapp.actions.reservations.update");
+          Route::post("reservations/destroy", [$actionController, 'destroy'])->name("netflexapp.actions.reservations.destroy");
+        });
+      });
     }
 
-    public function map()
-    {
-        if ($this->reservationsActionController) {
-            $actionController = $this->reservationsActionController;
-            Route::middleware('api')->prefix(".well-known/netflex/actions/")->group(function () use ($actionController) {
-                Route::middleware(WebhookAuthMiddleware::class)->group(function () use ($actionController) {
-                    Route::any('reservations/form', [FormController::class, 'createForm'])->name('netflexapp.actions.reservations.form');
-                    Route::post("reservations/create", [$actionController, 'create'])->name("netflexapp.actions.reservations.create");
-                    Route::post("reservations/update", [$actionController, 'update'])->name("netflexapp.actions.reservations.update");
-                    Route::post("reservations/destroy", [$actionController, 'destroy'])->name("netflexapp.actions.reservations.destroy");
-                });
-            });
-        }
+    if ($this->ordersRefundActionController) {
+      $formDescriber = $this->ordersRefundFormController;
+      $actionController = $this->ordersRefundActionController;
 
-        if ($this->ordersRefundActionController) {
-            $formDescriber = $this->ordersRefundFormController;
-            $actionController = $this->ordersRefundActionController;
-
-            Route::group([
-                'middleware' => ['api', WebhookAuthMiddleware::class],
-                'prefix' => '.well-known/netflex/actions/'
-            ], function () use ($formDescriber, $actionController) {
-                Route::any('orders/refunds/form/order', [$formDescriber, 'renderRefundOrderForm']);
-                Route::any('orders/refunds/form/cartitem', [$formDescriber, 'renderRefundCartItemForm']);
-                Route::post('orders/refunds/refund/order', [$actionController, 'refundOrder']);
-                Route::post('orders/refunds/refund/cartitem', [$actionController, 'refundCartItem']);
-            });
-        }
+      Route::group([
+        'middleware' => ['api', WebhookAuthMiddleware::class],
+        'prefix' => '.well-known/netflex/actions/'
+      ], function () use ($formDescriber, $actionController) {
+        Route::any('orders/refunds/form/order', [$formDescriber, 'renderRefundOrderForm']);
+        Route::any('orders/refunds/form/cartitem', [$formDescriber, 'renderRefundCartItemForm']);
+        Route::post('orders/refunds/refund/order', [$actionController, 'refundOrder']);
+        Route::post('orders/refunds/refund/cartitem', [$actionController, 'refundCartItem']);
+      });
     }
+
+    if ($this->moveSignupsController) {
+      Route::group([
+        'middleware' => ['api', WebhookAuthMiddleware::class],
+        'prefix' => '.well-known/netflex/actions/'
+      ], function () use ($formDescriber, $actionController) {
+        Route::get('signups/move/{id}', [$this->moveSignupsController, 'moveSignupForm']);
+        Route::post('signups/move/{id}', [$this->moveSignupsController, 'moveSignupAction']);
+      });
+    }
+  }
 }

--- a/src/Netflex/Actions/Requests/Signups/DeleteSignupsRequest.php
+++ b/src/Netflex/Actions/Requests/Signups/DeleteSignupsRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Netflex\Actions\Requests\Signups;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * @property ?int|string $to
+ */
+class DeleteSignupsRequest extends FormRequest
+{
+  public function rules()
+  {
+    return [
+      'ids.*' => ['numeric']
+    ];
+  }
+
+  public function getIds(): array
+  {
+    return $this->get('ids', []);
+  }
+}

--- a/src/Netflex/Actions/Requests/Signups/MoveSignupRequest.php
+++ b/src/Netflex/Actions/Requests/Signups/MoveSignupRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Netflex\Actions\Requests\Signups;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * @property ?int|string $to
+ */
+class MoveSignupRequest extends FormRequest
+{
+  public function rules()
+  {
+    return [
+      'to' => ['required', 'numeric']
+    ];
+  }
+
+}


### PR DESCRIPTION
This PR adds a few Signups related netflex actions.

* We add optional form fields for Moving entries, with acompanying custom functionality related to moving signups between entries.
* We add optional actions that replaces built in netflexapp delete signup action.
