### PR TITLE
Fix a hrefs being borked by CssToInlineStyles

### DIFF
--- a/src/Netflex/Newsletters/Newsletter.php
+++ b/src/Netflex/Newsletters/Newsletter.php
@@ -323,7 +323,7 @@ class Newsletter extends QueryableModel
   public function renderAndSave()
   {
     $content = $this->render()->toHtml();
-    $this->output = $this->inlineCss($content);
+    $this->output = mb_convert_entities($this->inlineCss($content));
     $this->outputText = mb_convert_entities((new Html2Text($content))->getText());
     $this->save();
   }

--- a/src/Netflex/Newsletters/Newsletter.php
+++ b/src/Netflex/Newsletters/Newsletter.php
@@ -2,19 +2,15 @@
 
 namespace Netflex\Newsletters;
 
-use Exception;
 use Html2Text\Html2Text;
-use Throwable;
-
-use Netflex\Query\QueryableModel;
-use Netflex\Query\Exceptions\NotFoundException;
-
-use Netflex\Newsletters\Traits\CastsDefaultFields;
-use Netflex\Newsletters\Traits\HidesDefaultFields;
-
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\HtmlString;
+use Netflex\Newsletters\Traits\CastsDefaultFields;
+use Netflex\Newsletters\Traits\HidesDefaultFields;
+use Netflex\Query\Exceptions\NotFoundException;
+use Netflex\Query\QueryableModel;
+use Throwable;
 use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
 
 /**
@@ -169,6 +165,18 @@ class Newsletter extends QueryableModel
   const TYPE_TRANSACTIONAL_CAMPAIGN = 'transactional_campaign';
 
   /**
+   * @param string $content
+   * @return string
+   */
+  public function inlineCss(string $content): string
+  {
+    $replaceWith = "wer90erjgfierjgi43j5829uy45293u428973yreguhrueirjghui9efjrtu89eiodkfjghrui9ekopwdfiu98gri0tk3";
+    $convertedContent = str_replace('href', $replaceWith, $content);
+    $convertedContent = (new CssToInlineStyles())->convert($convertedContent);
+    return str_replace($replaceWith, 'href', $convertedContent);
+  }
+
+  /**
    * Retrieves a record by key
    *
    * @param int|null $relationId
@@ -184,9 +192,9 @@ class Newsletter extends QueryableModel
   /**
    * Inserts a new record, and returns its id
    *
-   * @property int|null $relationId
-   * @property array $attributes
    * @return mixed
+   * @property array $attributes
+   * @property int|null $relationId
    */
   protected function performInsertRequest(?int $relationId = null, array $attributes = [])
   {
@@ -231,8 +239,8 @@ class Newsletter extends QueryableModel
   /**
    * Retrieve the model for a bound value.
    *
-   * @param  mixed  $rawValue
-   * @param  string|null $field
+   * @param mixed $rawValue
+   * @param string|null $field
    * @return \Illuminate\Database\Eloquent\Model|null
    * @throws NotFoundException
    */
@@ -264,7 +272,8 @@ class Newsletter extends QueryableModel
    *
    * @return NewsletterPage|null
    */
-  public function getPageAttribute(): ?NewsletterPage {
+  public function getPageAttribute(): ?NewsletterPage
+  {
     if ($page = NewsletterPage::where('id', $this->page_id)->first()) {
       return $page->loadRevision($page->revision);
     }
@@ -277,14 +286,15 @@ class Newsletter extends QueryableModel
    *
    * @return HtmlString
    */
-  public function render(): HtmlString {
+  public function render(): HtmlString
+  {
     if ($page = $this->page) {
-        App::setLocale($page->lang ?? App::getLocale());
-        return new HtmlString($page->toResponse(request()));
+      App::setLocale($page->lang ?? App::getLocale());
+      return new HtmlString($page->toResponse(request()));
     }
 
     return new HtmlString;
-}
+  }
 
   /**
    * Reunders preview of newsletter in html or text
@@ -297,7 +307,7 @@ class Newsletter extends QueryableModel
     $content = $this->render()->toHtml();
     $output = (new CssToInlineStyles())->convert($content);
     $outputText = (new Html2Text($content))->getText();
-    switch($type) {
+    switch ($type) {
       case 'text':
         return $outputText;
       default:
@@ -312,10 +322,10 @@ class Newsletter extends QueryableModel
    */
   public function renderAndSave()
   {
-      $content = $this->render()->toHtml();
-      $this->output = mb_convert_entities((new CssToInlineStyles())->convert($content));
-      $this->outputText = mb_convert_entities((new Html2Text($content))->getText());
-      $this->save();
+    $content = $this->render()->toHtml();
+    $this->output = $this->inlineCss($content);
+    $this->outputText = mb_convert_entities((new Html2Text($content))->getText());
+    $this->save();
   }
 
 }


### PR DESCRIPTION
An attempt to get around DOMDocument quoting hrefs

The library "CssToInlineStyles" which we use uses DOMDocument under the hood.

DOMDocument does a lot of dumb stuff. One of these dumb things is to "quote" content of href attributes. This seemingly only happens with href attributes, but I don't really know as this seems to be undocumented behaviour.

A test link of `<a href="{{ data.receipt_url}}">` will produce `<a href="%7B%7B%20data.receipt_url%20%7D%7D">`. While `<a hrf="{{ data.receipt_url }}>` will produce `<a hrf="{{ data.receipt_url }}">` as one "might expect".

My workaround is to change all references to href to a sufficiently random string (i banged my keyboard for a while), that is sufficiently unlikely to appear in the original text then feed that text through DOMDocument, then changing the text back to href afterwards. 

The objectively better alternative is to remove the plugin all together and instead applying css inlining after the final rendering of the email content. However, it seems a bit more risky as we're not entirely sure what other artifacting DOMDocument could grace us with.