### PR TITLE
Automation mails using laravel notifications

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
         "spatie/once": "^2.2",
         "brick/phonenumber": "^0.4.0",
         "html2text/html2text": "^4.3",
-        "tijsverkoyen/css-to-inline-styles": "^2.2"
+        "tijsverkoyen/css-to-inline-styles": "^2.2",
+        "salesforce/handlebars-php": "^3.0"
     },
     "require-dev": {
         "illuminate/cache": "^8.0|^9.0|^10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "009ab79b6d2eb96a14ba760e74a8273f",
+    "content-hash": "e087278c893826c2eca5c1c82cceff4f",
     "packages": [
         {
             "name": "apility/laravel-ngrok",
@@ -3975,6 +3975,63 @@
                 }
             ],
             "time": "2021-09-25T23:10:38+00:00"
+        },
+        {
+            "name": "salesforce/handlebars-php",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/salesforce/handlebars-php.git",
+                "reference": "d3a0552d85472249617ef6b56197c844d62d2ac3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/salesforce/handlebars-php/zipball/d3a0552d85472249617ef6b56197c844d62d2ac3",
+                "reference": "d3a0552d85472249617ef6b56197c844d62d2ac3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Handlebars": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "fzerorubigd",
+                    "email": "fzerorubigd@gmail.com"
+                },
+                {
+                    "name": "Behrooz Shabani (everplays)",
+                    "email": "everplays@gmail.com"
+                },
+                {
+                    "name": "Mardix",
+                    "homepage": "https://github.com/mardix"
+                }
+            ],
+            "description": "Handlebars processor for php",
+            "homepage": "http://www.github.com/salesforce/handlebars-php",
+            "keywords": [
+                "handlebars",
+                "mustache",
+                "templating"
+            ],
+            "support": {
+                "issues": "https://github.com/salesforce/handlebars-php/issues",
+                "source": "https://github.com/salesforce/handlebars-php/tree/3.0.1"
+            },
+            "time": "2023-01-12T16:24:23+00:00"
         },
         {
             "name": "spatie/once",
@@ -9386,5 +9443,5 @@
         "php": "^7.4|^8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/framework.iml
+++ b/framework.iml
@@ -2,7 +2,56 @@
 <module type="WEB_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
-    <content url="file://$MODULE_DIR$" />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex" isTestSource="false" packagePrefix="Netflex\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/API" isTestSource="false" packagePrefix="Netflex\API\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/API/" isTestSource="false" packagePrefix="Netflex\API\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Actions" isTestSource="false" packagePrefix="Netflex\Actions\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Actions/" isTestSource="false" packagePrefix="Netflex\Actions\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Breadcrumbs" isTestSource="false" packagePrefix="Netflex\Breadcrumbs\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Breadcrumbs/" isTestSource="false" packagePrefix="Netflex\Breadcrumbs\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Commerce" isTestSource="false" packagePrefix="Netflex\Commerce\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Commerce/" isTestSource="false" packagePrefix="Netflex\Commerce\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Console" isTestSource="false" packagePrefix="Netflex\Console\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Console/" isTestSource="false" packagePrefix="Netflex\Console\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Customers" isTestSource="false" packagePrefix="Netflex\Customers\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Customers/" isTestSource="false" packagePrefix="Netflex\Customers\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Encryption" isTestSource="false" packagePrefix="Netflex\Encryption\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Encryption/" isTestSource="false" packagePrefix="Netflex\Encryption\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Files" isTestSource="false" packagePrefix="Netflex\Files\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Files/" isTestSource="false" packagePrefix="Netflex\Files\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Foundation" isTestSource="false" packagePrefix="Netflex\Foundation\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Foundation/" isTestSource="false" packagePrefix="Netflex\Foundation\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Http" isTestSource="false" packagePrefix="Netflex\Http\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Http/" isTestSource="false" packagePrefix="Netflex\Http\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Log" isTestSource="false" packagePrefix="Netflex\Log\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Log/" isTestSource="false" packagePrefix="Netflex\Log\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/MessageChannel" isTestSource="false" packagePrefix="Netflex\MessageChannel\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/MessageChannel/" isTestSource="false" packagePrefix="Netflex\MessageChannel\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Newsletters" isTestSource="false" packagePrefix="Netflex\Newsletters\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Newsletters/" isTestSource="false" packagePrefix="Netflex\Newsletters\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Notifications" isTestSource="false" packagePrefix="Netflex\Notifications\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Notifications/" isTestSource="false" packagePrefix="Netflex\Notifications\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Pages" isTestSource="false" packagePrefix="Netflex\Pages\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Pages/" isTestSource="false" packagePrefix="Netflex\Pages\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Query" isTestSource="false" packagePrefix="Netflex\Query\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Query/" isTestSource="false" packagePrefix="Netflex\Query\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Query/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Renderer" isTestSource="false" packagePrefix="Netflex\Render\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Renderer/" isTestSource="false" packagePrefix="Netflex\Render\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/SDK" isTestSource="false" packagePrefix="Netflex\SDK\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/SDK/" isTestSource="false" packagePrefix="Netflex\SDK\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Scheduler" isTestSource="false" packagePrefix="Netflex\Scheduler\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Scheduler/" isTestSource="false" packagePrefix="Netflex\Scheduler\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Signups/" isTestSource="false" packagePrefix="Netflex\Signups\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Structures" isTestSource="false" packagePrefix="Netflex\Structure\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Structures/" isTestSource="false" packagePrefix="Netflex\Structure\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Support" isTestSource="false" packagePrefix="Netflex\Support\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Support/" isTestSource="false" packagePrefix="Netflex\Support\" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Netflex/Support/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/salesforce/handlebars-php" />
+    </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>

--- a/src/Netflex/Customers/Customer.php
+++ b/src/Netflex/Customers/Customer.php
@@ -283,6 +283,7 @@ class Customer extends Model implements Authenticatable
             return $attributes['consent']['id'] == (($consent instanceof Consent) ? $consent->id : $consent);
           }
         }
+        return true;
       })
       ->values()
       ->map(function ($consent) {
@@ -301,7 +302,7 @@ class Customer extends Model implements Authenticatable
 
   /**
    * Determines if the customer has a currently active consent assignment for the given consent
-   * 
+   *
    * @param Consent|int $consent
    * @return boolean
    */
@@ -358,7 +359,7 @@ class Customer extends Model implements Authenticatable
 
   /**
    * Assign consent to customer
-   * 
+   *
    * @param Consent|int $consent
    * @param string $source
    * @param array $options

--- a/src/Netflex/Newsletters/AutomationMailChannel.php
+++ b/src/Netflex/Newsletters/AutomationMailChannel.php
@@ -1,7 +1,9 @@
 <?php
+
 namespace Netflex\Newsletters;
 
 use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\Log;
 use Netflex\API\Facades\API;
 use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
 
@@ -14,16 +16,25 @@ class AutomationMailChannel
 
     $body = $this->inlineCss((string)$message);
 
-    API::post('relations/notifications', array_filter([
+    $to = [[
+      'mail' => $notifiable->mail,
+      'name' => $notifiable->name ?: $notifiable->mail
+    ]];
+
+    $id = API::post('relations/notifications', array_filter([
       'subject' => $message->getSubject(),
-      'to' => [$notifiable->mail],
-      'from' => $message->getFrom() ?? variable('mail_sender_mail') ?: null,
-      'reply_to' => $message->getReplyTo(),
+      'to' => $to,
+      'from' => $message->getFrom(),
+      //'reply_to' => $replyTo,
       'body' => base64_encode($body),
-      'newsletter_id' => $message->getNewsletterId(),
       'use_blank_template' => true,
+      'newsletter_id' => $message->getNewsletter()->id,
       //'attachments' => $attachments
     ]));
+
+    $type = get_class($notification);
+    $id = data_get($id, 'notification_id', 'unknown');
+    Log::debug("Sending Automation Email of type $type to $notifiable->mail. Notification id = $id");
   }
 
   private function inlineCss(string $content, $tags = ['src', 'href']): string

--- a/src/Netflex/Newsletters/AutomationMailChannel.php
+++ b/src/Netflex/Newsletters/AutomationMailChannel.php
@@ -2,9 +2,11 @@
 
 namespace Netflex\Newsletters;
 
+use Illuminate\Notifications\Events\NotificationSent;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Facades\Log;
 use Netflex\API\Facades\API;
+use Netflex\Customers\Customer;
 use Netflex\Newsletters\Contracts\IsConsentConstrained;
 use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
 
@@ -37,12 +39,13 @@ class AutomationMailChannel
       'body' => base64_encode($body),
       'use_blank_template' => true,
       'newsletter_id' => $message->getNewsletter()->id,
+      'customer_id' => $notifiable instanceof Customer ? $notifiable->id : null,
       //'attachments' => $attachments
     ]));
 
     $type = get_class($notification);
-    $id = data_get($id, 'notification_id', 'unknown');
-    Log::debug("Sending Automation Email of type $type to $notifiable->mail. Notification id = $id");
+    $id = data_get($id, 'notification_id');
+    return $id;
   }
 
   private function inlineCss(string $content, $tags = ['src', 'href']): string

--- a/src/Netflex/Newsletters/AutomationMailChannel.php
+++ b/src/Netflex/Newsletters/AutomationMailChannel.php
@@ -16,8 +16,8 @@ class AutomationMailChannel
 
     API::post('relations/notifications', array_filter([
       'subject' => $message->getSubject(),
-      'to' => $notifiable->mail,
-      'from' => $message->getFrom() ?? variable('mail_sender_mail'),
+      'to' => [$notifiable->mail],
+      'from' => $message->getFrom() ?? variable('mail_sender_mail') ?: null,
       'reply_to' => $message->getReplyTo(),
       'body' => base64_encode($body),
       'newsletter_id' => $message->getNewsletterId(),

--- a/src/Netflex/Newsletters/AutomationMailChannel.php
+++ b/src/Netflex/Newsletters/AutomationMailChannel.php
@@ -2,6 +2,7 @@
 
 namespace Netflex\Newsletters;
 
+use Html2Text\Html2Text;
 use Illuminate\Notifications\Notification;
 use Netflex\API\Facades\API;
 use Netflex\Customers\Customer;
@@ -41,6 +42,7 @@ class AutomationMailChannel
       'from' => $message->getFrom(),
       'reply_to' => $message->getReplyTo(),
       'body' => base64_encode($body),
+      'text_body' => base64_encode((new Html2Text($body))->getText()),
       'use_blank_template' => true,
       'newsletter_id' => $message->getNewsletter()->id,
       'customer_id' => $notifiable instanceof Customer ? $notifiable->id : null,

--- a/src/Netflex/Newsletters/AutomationMailChannel.php
+++ b/src/Netflex/Newsletters/AutomationMailChannel.php
@@ -2,9 +2,7 @@
 
 namespace Netflex\Newsletters;
 
-use Illuminate\Notifications\Events\NotificationSent;
 use Illuminate\Notifications\Notification;
-use Illuminate\Support\Facades\Log;
 use Netflex\API\Facades\API;
 use Netflex\Customers\Customer;
 use Netflex\Newsletters\Contracts\IsConsentConstrained;
@@ -20,7 +18,7 @@ class AutomationMailChannel
     if ($notification instanceof IsConsentConstrained) {
       $acceptedConsents = collect($notification->requiredConsents());
       if ($acceptedConsents->count() > 0 && $acceptedConsents->filter(fn($id) => $notifiable->hasConsent($id))->count() === 0) {
-        return;
+        return null;
       }
     }
 
@@ -35,15 +33,15 @@ class AutomationMailChannel
       'subject' => $message->getSubject(),
       'to' => $to,
       'from' => $message->getFrom(),
-      //'reply_to' => $replyTo,
+      'reply_to' => $message->getReplyTo(),
       'body' => base64_encode($body),
       'use_blank_template' => true,
       'newsletter_id' => $message->getNewsletter()->id,
       'customer_id' => $notifiable instanceof Customer ? $notifiable->id : null,
+      'track_links' => 'HtmlOnly',
       //'attachments' => $attachments
     ]));
-
-    $type = get_class($notification);
+    
     $id = data_get($id, 'notification_id');
     return $id;
   }

--- a/src/Netflex/Newsletters/AutomationMailChannel.php
+++ b/src/Netflex/Newsletters/AutomationMailChannel.php
@@ -1,0 +1,37 @@
+<?php
+namespace Netflex\Newsletters;
+
+use Illuminate\Notifications\Notification;
+use Netflex\API\Facades\API;
+use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
+
+class AutomationMailChannel
+{
+  public function send(object $notifiable, Notification $notification)
+  {
+    /** @var \Netflex\Newsletters\AutomationMailMessage|\Netflex\Newsletters\Contracts\AutomationMailNotification $message */
+    $message = $notification->toAutomationMail($notifiable);
+
+    $body = $this->inlineCss((string)$message);
+
+    API::post('relations/notifications', array_filter([
+      'subject' => $message->getSubject(),
+      'to' => $notifiable->mail,
+      'from' => $message->getFrom() ?? variable('mail_sender_mail'),
+      'reply_to' => $message->getReplyTo(),
+      'body' => base64_encode($body),
+      'newsletter_id' => $message->getNewsletterId(),
+      'use_blank_template' => true,
+      //'attachments' => $attachments
+    ]));
+  }
+
+  private function inlineCss(string $content, $tags = ['src', 'href']): string
+  {
+    $replaceWith = "wer90erjgfierjgi43j5829uy45293u428973yreguhrueirjghui9efjrtu89eiodkfjghrui9ekopwdfiu98gri0tk3";
+    $replacements = array_map(fn($str) => "$replaceWith$str", $tags);
+    $convertedContent = str_replace($tags, $replacements, $content);
+    $convertedContent = (new CssToInlineStyles())->convert($convertedContent);
+    return str_replace($replacements, $tags, $convertedContent);
+  }
+}

--- a/src/Netflex/Newsletters/AutomationMailChannel.php
+++ b/src/Netflex/Newsletters/AutomationMailChannel.php
@@ -5,14 +5,20 @@ namespace Netflex\Newsletters;
 use Illuminate\Notifications\Notification;
 use Netflex\API\Facades\API;
 use Netflex\Customers\Customer;
+use Netflex\Newsletters\Contracts\AutomationMailNotification;
 use Netflex\Newsletters\Contracts\IsConsentConstrained;
 use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
 
 class AutomationMailChannel
 {
+  /**
+   * @param object $notifiable
+   * @param Notification|AutomationMailNotification $notification
+   * @return array|mixed|null
+   */
   public function send(object $notifiable, Notification $notification)
   {
-    /** @var \Netflex\Newsletters\AutomationMailMessage|\Netflex\Newsletters\Contracts\AutomationMailNotification $message */
+    /** @var \Netflex\Newsletters\AutomationMailMessage $message */
     $message = $notification->toAutomationMail($notifiable);
 
     if ($notification instanceof IsConsentConstrained) {
@@ -39,9 +45,10 @@ class AutomationMailChannel
       'newsletter_id' => $message->getNewsletter()->id,
       'customer_id' => $notifiable instanceof Customer ? $notifiable->id : null,
       'track_links' => 'HtmlOnly',
+      'track_opens' => true,
       //'attachments' => $attachments
     ]));
-    
+
     $id = data_get($id, 'notification_id');
     return $id;
   }

--- a/src/Netflex/Newsletters/AutomationMailChannel.php
+++ b/src/Netflex/Newsletters/AutomationMailChannel.php
@@ -5,6 +5,7 @@ namespace Netflex\Newsletters;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Facades\Log;
 use Netflex\API\Facades\API;
+use Netflex\Newsletters\Contracts\IsConsentConstrained;
 use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
 
 class AutomationMailChannel
@@ -13,6 +14,13 @@ class AutomationMailChannel
   {
     /** @var \Netflex\Newsletters\AutomationMailMessage|\Netflex\Newsletters\Contracts\AutomationMailNotification $message */
     $message = $notification->toAutomationMail($notifiable);
+
+    if ($notification instanceof IsConsentConstrained) {
+      $acceptedConsents = collect($notification->requiredConsents());
+      if ($acceptedConsents->count() > 0 && $acceptedConsents->filter(fn($id) => $notifiable->hasConsent($id))->count() === 0) {
+        return;
+      }
+    }
 
     $body = $this->inlineCss((string)$message);
 

--- a/src/Netflex/Newsletters/AutomationMailMessage.php
+++ b/src/Netflex/Newsletters/AutomationMailMessage.php
@@ -20,7 +20,7 @@ class AutomationMailMessage implements \Stringable
   private array $replacementTags = [];
   private ?string $subject = null;
 
-  private ?string $from = null;
+  private ?array $from = null;
   private ?string $replyTo = null;
 
   public function withTemplate(int $id): self
@@ -47,9 +47,12 @@ class AutomationMailMessage implements \Stringable
     return $this;
   }
 
-  public function withFromAddress(string $address)
+  public function withFromAddress(?string $address = null, ?string $name = null)
   {
-    $this->from = $address;
+    $this->from = [
+      'name' => $name ?: $address ?: variable('mail_sender_name'),
+      'mail' => $address ?: variable('mail_sender_mail')
+    ];
     return $this;
   }
 
@@ -77,9 +80,11 @@ class AutomationMailMessage implements \Stringable
     return static::$cache[$this->mailId] ?? null;
   }
 
-  public function getNewsletterId(): ?int {
+  public function getNewsletterId(): ?int
+  {
     return $this->mailId;
   }
+
   public function getSubject()
   {
     $handlebars = new Handlebars([
@@ -95,9 +100,12 @@ class AutomationMailMessage implements \Stringable
     return $this->replyTo;
   }
 
-  public function getFrom(): ?string
+  public function getFrom(): array
   {
-    return $this->from;
+    return $this->from ?: [
+      'name' => variable('mail_sender_name'),
+      'mail' => variable('mail_sender_mail')
+    ];
   }
 
   public function __toString()

--- a/src/Netflex/Newsletters/AutomationMailMessage.php
+++ b/src/Netflex/Newsletters/AutomationMailMessage.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Netflex\Newsletters;
+
+use Carbon\Carbon;
+use Handlebars\Handlebars;
+use Handlebars\Helpers;
+use Handlebars\Loader\StringLoader;
+use Illuminate\Support\Facades\App;
+use Netflex\Commerce\Order;
+use Netflex\Customers\Customer;
+use Netflex\Foundation\Template;
+
+class AutomationMailMessage implements \Stringable
+{
+  private static array $cache = [];
+
+  private ?int $mailId = null;
+  private array $payload = [];
+  private array $replacementTags = [];
+  private ?string $subject = null;
+
+  private ?string $from = null;
+  private ?string $replyTo = null;
+
+  public function withTemplate(int $id): self
+  {
+    $this->mailId = $id;
+    return $this;
+  }
+
+  public function withOrder(Order $order): self
+  {
+    $this->replacementTags['order'] = $order->toArray();
+    return $this;
+  }
+
+  public function withCustomer(Customer $customer): self
+  {
+    $this->replacementTags['customer'] = $customer->toArray();
+    return $this;
+  }
+
+  public function withVariables(array $payload)
+  {
+    $this->payload = $payload;
+    return $this;
+  }
+
+  public function withFromAddress(string $address)
+  {
+    $this->from = $address;
+    return $this;
+  }
+
+  public function withReplyTo(string $replyTo)
+  {
+    $this->replyTo = $replyTo;
+    return $this;
+  }
+
+  public function withData(array $replacementTags)
+  {
+    $this->replacementTags['data'] = $replacementTags;
+    return $this;
+  }
+
+  public static function make(): self
+  {
+    return new static();
+  }
+
+  public function getNewsletter(): ?Newsletter
+  {
+    if (!$this->mailId) throw new \Exception("You must supply a mail id");
+    static::$cache[$this->mailId] ??= Newsletter::find($this->mailId);
+    return static::$cache[$this->mailId] ?? null;
+  }
+
+  public function getNewsletterId(): ?int {
+    return $this->mailId;
+  }
+  public function getSubject()
+  {
+    $handlebars = new Handlebars([
+      'loader' => new StringLoader(),
+      'helpers' => new Helpers(),
+    ]);
+    return $handlebars->render($this->subject ?: $this->getNewsletter()->subject ?? '', $this->replacementTags);
+  }
+
+  public function getReplyTo(): ?string
+  {
+    return $this->replyTo;
+  }
+
+  public function getFrom(): ?string
+  {
+    return $this->from;
+  }
+
+  public function __toString()
+  {
+    $mail = $this->getNewsletter();
+    $page = data_get($mail, 'page');
+    /** @var Template $template */
+    $template = data_get($mail, 'page.template');
+    if (!$template) throw new \Exception("Expected the newsletter to return a page and a template, template is missing");
+
+    current_newsletter($mail);
+    current_page($page);
+
+    if ($locale = $page->lang ?: optional($page->master)->lang) {
+      App::setLocale($locale);
+      Carbon::setLocale($locale);
+    }
+
+    $handlebars = new Handlebars([
+      'loader' => new StringLoader(),
+      'helpers' => new Helpers(),
+    ]);
+    $response = $template->toResponse($this->payload);
+    if (current_mode() === 'live') {
+      return $handlebars->render($response, $this->replacementTags);
+    }
+    return $response;
+
+  }
+}

--- a/src/Netflex/Newsletters/AutomationMailMessage.php
+++ b/src/Netflex/Newsletters/AutomationMailMessage.php
@@ -16,7 +16,7 @@ class AutomationMailMessage implements \Stringable
   private static array $cache = [];
 
   private ?int $mailId = null;
-  private array $payload = [];
+  private array $data = [];
   private array $replacementTags = [];
   private ?string $subject = null;
 
@@ -41,9 +41,16 @@ class AutomationMailMessage implements \Stringable
     return $this;
   }
 
-  public function withVariables(array $payload)
+  /**
+   * Server side variables that will be passed to the template as variables.
+   * Just like when using view('view', $variables);
+   *
+   * @param array $variables
+   * @return $this
+   */
+  public function withData(array $variables)
   {
-    $this->payload = $payload;
+    $this->data = $variables;
     return $this;
   }
 
@@ -62,7 +69,14 @@ class AutomationMailMessage implements \Stringable
     return $this;
   }
 
-  public function withData(array $replacementTags)
+  /**
+   * Replacement tags that will be replaced using handlebars.
+   * This is to allow the user to add certain fields into their manually edited text.
+   *
+   * @param array $replacementTags
+   * @return $this
+   */
+  public function withReplacementTags(array $replacementTags)
   {
     $this->replacementTags['data'] = $replacementTags;
     return $this;
@@ -128,7 +142,8 @@ class AutomationMailMessage implements \Stringable
       'loader' => new StringLoader(),
       'helpers' => new Helpers(),
     ]);
-    $response = $template->toResponse($this->payload);
+
+    $response = $template->toResponse($this->data);
     if (current_mode() === 'live') {
       return $handlebars->render($response, $this->replacementTags);
     }

--- a/src/Netflex/Newsletters/AutomationMailMessage.php
+++ b/src/Netflex/Newsletters/AutomationMailMessage.php
@@ -56,9 +56,9 @@ class AutomationMailMessage implements \Stringable
     return $this;
   }
 
-  public function withReplyTo(string $replyTo)
+  public function withReplyTo(string $address, ?string $name = null)
   {
-    $this->replyTo = $replyTo;
+    $this->replyTo = $name ? "$name <$address>" : $address;
     return $this;
   }
 

--- a/src/Netflex/Newsletters/AutomationMailMessage.php
+++ b/src/Netflex/Newsletters/AutomationMailMessage.php
@@ -86,6 +86,7 @@ class AutomationMailMessage implements \Stringable
       'loader' => new StringLoader(),
       'helpers' => new Helpers(),
     ]);
+
     return $handlebars->render($this->subject ?: $this->getNewsletter()->subject ?? '', $this->replacementTags);
   }
 

--- a/src/Netflex/Newsletters/Contracts/AutomationMailNotification.php
+++ b/src/Netflex/Newsletters/Contracts/AutomationMailNotification.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Netflex\Newsletters\Contracts;
+
+use Netflex\Newsletters\AutomationMailMessage;
+
+interface AutomationMailNotification
+{
+  public function toAutomationMail(): AutomationMailMessage;
+}

--- a/src/Netflex/Newsletters/Contracts/IsConsentConstrained.php
+++ b/src/Netflex/Newsletters/Contracts/IsConsentConstrained.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Netflex\Newsletters\Contracts;
+
+interface IsConsentConstrained
+{
+
+  /**
+   * Returns a list of consents of which one needs to be active in order for the mail to be sent.
+   * @return array<int>
+   */
+  public function requiredConsents(): array;
+}

--- a/src/Netflex/Newsletters/Facades/AutomationMails.php
+++ b/src/Netflex/Newsletters/Facades/AutomationMails.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Netflex\Newsletters\Facades;
+
+class AutomationMails
+{
+
+  /** @noinspection PhpUndefinedMethodInspection */
+  public static function registerAutomationMail(int $mailId, string $notification_class)
+  {
+    try {
+      $errorReason = "The notification class must have static method called [automationPreviewParameters] which returns a key/value array that maps all variables required by the class constructor";
+      $rms = new \ReflectionMethod($notification_class, 'automationPreviewParameters');
+      if (!$rms->isStatic()) {
+        throw static::makeException($errorReason);
+      }
+    } catch (\ReflectionException $exception) {
+      throw static::makeException($errorReason, $exception);
+    }
+
+    try {
+      $errorReason = "The notification class must have a static method called [automationPreviewNotifiable] which takes the notification as an arguments and returns the preview notifiable";
+      $rms = new \ReflectionMethod($notification_class, 'automationPreviewNotifiable');
+      if (!$rms->isStatic()) {
+        throw static::makeException($errorReason);
+      }
+    } catch (\ReflectionException $exception) {
+      throw static::makeException($errorReason, $exception);
+    }
+
+    app()
+      ->bind("automation-mail.$mailId", fn() => app($notification_class, $notification_class::automationPreviewParameters()));
+  }
+
+
+  private static function makeException(string $text, ?\Exception $exception = null)
+  {
+    return new \Exception(
+      $exception ? $exception->getCode() : null,
+      $exception
+    );
+  }
+}

--- a/src/Netflex/Newsletters/Providers/NewslettersServiceProvider.php
+++ b/src/Netflex/Newsletters/Providers/NewslettersServiceProvider.php
@@ -5,7 +5,9 @@ namespace Netflex\Newsletters\Providers;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Config;
 
+use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\ServiceProvider;
+use Netflex\Newsletters\AutomationMailChannel;
 use Netflex\Pages\Controllers\Controller;
 
 class NewslettersServiceProvider extends ServiceProvider
@@ -21,6 +23,7 @@ class NewslettersServiceProvider extends ServiceProvider
 
   public function boot()
   {
+    Notification::extend('automation-mail', fn($app) => new AutomationMailChannel());
 
     $this->publishes([
       __DIR__ . '/../config/newsletters.php' => $this->app->configPath('newsletters.php')
@@ -53,6 +56,6 @@ class NewslettersServiceProvider extends ServiceProvider
 
   protected function registerDirectives()
   {
-    
+
   }
 }

--- a/src/Netflex/Pages/Providers/RouteServiceProvider.php
+++ b/src/Netflex/Pages/Providers/RouteServiceProvider.php
@@ -271,6 +271,14 @@ class RouteServiceProvider extends ServiceProvider
 
   protected function handleNewsletter(Request $request, JwtPayload $payload)
   {
+    if(app()->has("automation-mail.$payload->newsletter_id")) {
+      $automationMail = app()->get("automation-mail.$payload->newsletter_id");
+      $class = get_class($automationMail);
+      
+      return $automationMail
+        ->toAutomationMail($class::automationNotifiable($automationMail));
+    }
+
     if ($newsletter = Newsletter::where('id', $payload->newsletter_id)->first()) {
 
       $automationMail = null;

--- a/src/Netflex/Pages/resources/views/blocks.blade.php
+++ b/src/Netflex/Pages/resources/views/blocks.blade.php
@@ -1,8 +1,24 @@
-@php($originalHash = blockhash())
+@php
+  $originalHash = blockhash()
+@endphp
 @foreach($blocks as $block)
-  @php(@list($component, $hash) = $block)
-  @php(blockhash($hash))
-  <x-dynamic-component :component="$component" :variables="$variables" />
+
+  @php
+    @list($component, $hash) = $block;
+    blockhash($hash)
+  @endphp
+
+  @if(config('pages.expand-attributes', false))
+    @php
+      /** @var \Illuminate\View\ComponentAttributeBag $attributes2 */
+      $attributes2 = new \Illuminate\View\ComponentAttributeBag();
+      $attributes2->setAttributes($__data);
+      $attributes2 = $attributes2->whereDoesntStartWith("__");
+    @endphp
+    <x-dynamic-component :component="$component" :attributes="$attributes2" />
+  @else
+    <x-dynamic-component :component="$component" :variables="$variables"/>
+  @endif
   @php(blockhash(null))
 @endforeach
 


### PR DESCRIPTION
This PR adds some alternative ways of using Automation mails that are a little bit more in line laravel and that gets around the quirky way they are used today. 

# Usage
This is not replacing the old generic automation mails. This is meant to replace automation mails we're hard coding. Such as for receipts.

## Using notifications 
The biggest change is that we are using laravel's notification system instead of a home-built forced job based solution. This gives us all the bells and whistles we want, queued dispatching, delays and what not, for example without using some homebuilt jobs that are forced. 

Implementing this is as easy as creating a new notification with `php artisan make:notification` adding `automation-mail` to the via array and implement toAutomationMail and make it return an `AutomationMailMessage` object as shown in the example below.

```php
public function toAutomationMail($notifiable): AutomationMailMessage {
        return (new AutomationMailMessage())
            ->withTemplate(164)
            ->withCustomer($notifiable)
            ->withData([
                'order' => $this->order,
                'customer' => $notifiable
            ])
            ->withReplacementTags([
                'firstname' => $this->order->checkout->firstname
            ])
            ->withOrder($this->order);
    }
```

`withData` are variables that will be made available in the blade template rendered.
`withReplacementTags` are variables that will be passed to handlebars.

## Local rendering
* This solution also moves rendering of the email to the site, utilizing the notifications endpoint to send the mail.
It still performs the same kind of preprocessing, such as inlining css and extracting text from the email.
* Subsequently, the notifications endpoint has gotten a few new parameters in order to tag the outbound mail with the automation_mail newsletter, as well as the ability to turn on open and link tracking on notifications. This way statistics are still intact, including link and open tracking.
* Another positive of local rendering is that we can now include and use blade when rendering the emails, in addition to handlebars. There are ways to mock values when in preview mode. 
  * Instead of having to type {{{ cart_item_table }}} when making receipts, you can just show the user the table as it will be shown to the user. 
  * We don't use the prerendered template made by renderAndSave(), its not meaningfully slower to re-render the mails on the fly. 

## Local and Netflex Preview
Mails can be previewed using similar code, both replacement tags and blade rendering will be run, then you will be shown the response.
```php
Route::get('/-/test-automation-mail', function(User $user) {
   return (new MyNotification)->toAutomationMail($user);
});
```

In the case that you make notifications that require some arguments to be passed to its constructor, you can define a function that returns the necessary arguments. Same goes for the mock preview notifiable, in case you use that data as part of the output.

Example of both functions go here:
```php
public function __construct(Order $order)
    {
        $this->order = $order;
    }

/// We use app($class, $class::automationPreviewParameters()) under the hood,
/// all you need to do is create this key/value array with keys that match variable names
/// and valid values for those parameters.
 public static function automationPreviewParameters(): array {
        return [
            'order' => Order::retrieveBySecret('someordersecretgoeshere'),
        ];
    }
public static function automationPreviewNotifiable($newsletter): object {
        return User::find($newsletter->order->customer_id);
    }
```
